### PR TITLE
Settings section: nested editors, unified DataTable, save-bar + reload UX

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -5,6 +5,7 @@ import { EntityView } from "./views/EntityView";
 import { LibraryView } from "./views/LibraryView";
 import { ComponentCatalog } from "./views/ComponentCatalog";
 import { ImportCSVView } from "./views/ImportCSVView";
+import { SettingsView } from "./views/SettingsView";
 import { ToastContainer } from "./views/ToastContainer";
 import { AgentModal } from "./components/agent/AgentModal";
 import { themeAtom, resolveTheme } from "./atoms/theme";
@@ -81,6 +82,8 @@ export function App() {
       <div className="flex-1 min-h-0 flex flex-col">
         {appView === "import-csv" ? (
           <ImportCSVView />
+        ) : appView === "settings" ? (
+          <SettingsView onNavigate={handleNavigate} />
         ) : appView === "library" ? (
           <LibraryView />
         ) : (

--- a/app/src/atoms/highlights.ts
+++ b/app/src/atoms/highlights.ts
@@ -1,0 +1,26 @@
+import { atom } from "jotai";
+import type { NormRect } from "./selection";
+
+/** A standalone text highlight — a marked passage with no relationship/target.
+ *  Created from the document selection menu's Highlighter button. Unlike a
+ *  reference highlight (which only paints while its row is active), a standalone
+ *  highlight is always visible on its document. Scoped to the document entity it
+ *  was drawn on so it doesn't bleed across focal entities. */
+export interface Highlight {
+  id: string;
+  /** The document entity this highlight belongs to (the focused entity). */
+  entityId: string;
+  text: string;
+  page: number;
+  /** Exact per-line page-relative rects (from the selection Range), so the
+   *  highlight paints the real selected geometry — not a line-break guess. */
+  rects: NormRect[];
+  color: string;
+  createdAt: string;
+}
+
+export const highlightsAtom = atom<Highlight[]>([]);
+
+/** Calm highlighter tint — a warm amber that reads as "marked", distinct from
+ *  the entity-coloured reference highlights. */
+export const HIGHLIGHT_COLOR = "#E0A93B";

--- a/app/src/atoms/navigation.ts
+++ b/app/src/atoms/navigation.ts
@@ -1,7 +1,8 @@
-import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 
-export type AppView = "entity" | "library" | "catalog" | "import-csv";
+export type AppView = "entity" | "library" | "catalog" | "import-csv" | "settings";
 
-/** Land on the Library index — it's the home surface now that entities are
- *  browsable as standalone records. */
-export const appViewAtom = atom<AppView>("library");
+/** Which top-level surface is showing. Persisted so a browser reload keeps you
+ *  on the same page instead of bouncing back to the Library home. Default
+ *  (first visit) lands on the Library index. */
+export const appViewAtom = atomWithStorage<AppView>("uwazi:appView", "library");

--- a/app/src/atoms/selection.ts
+++ b/app/src/atoms/selection.ts
@@ -1,9 +1,21 @@
 import { atom } from "jotai";
 
+export interface NormRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
 export interface TextSelectionState {
   text: string;
   page: number;
-  rect: { top: number; left: number; width: number; height: number };
+  /** Page-relative (0-1) bounding box of the whole selection. */
+  rect: NormRect;
+  /** Page-relative per-line rects from the selection Range's getClientRects().
+   *  These are the exact line boxes the browser computed, so highlights paint
+   *  precisely instead of approximating line breaks. */
+  rects: NormRect[];
   /** Screen coordinates for floating menu positioning */
   screenX: number;
   screenY: number;

--- a/app/src/atoms/settings.ts
+++ b/app/src/atoms/settings.ts
@@ -1,0 +1,105 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import type { LucideIcon } from "lucide-react";
+import {
+  User,
+  LayoutDashboard,
+  Users,
+  SlidersHorizontal,
+  Menu,
+  FileText,
+  Languages,
+  Globe,
+  Filter,
+  LayoutTemplate,
+  BookOpen,
+  Spline,
+  ScanText,
+  AlignLeft,
+  Archive,
+  Activity,
+  Code2,
+  Upload,
+  FileSpreadsheet,
+  ExternalLink,
+} from "lucide-react";
+import type { AppView } from "./navigation";
+
+/** A single settings destination. Mirrors Uwazi's V2 SettingsNavigation IA
+ *  (huridocs/uwazi · app/react/V2/Routes/Settings/SettingsNavigation.tsx).
+ *  `navigateTo` lets an item jump to a different top-level app view instead of
+ *  swapping the settings section (Import CSV reuses our existing import view);
+ *  `external` renders an outbound link. */
+export interface SettingsItem {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  badge?: string;
+  navigateTo?: AppView;
+  external?: string;
+}
+
+export interface SettingsGroup {
+  id: string;
+  label?: string;
+  items: SettingsItem[];
+}
+
+export const settingsGroups: SettingsGroup[] = [
+  {
+    id: "user",
+    label: "User",
+    items: [{ id: "account", label: "Account", icon: User }],
+  },
+  {
+    id: "system",
+    label: "System",
+    items: [
+      { id: "dashboard", label: "Dashboard", icon: LayoutDashboard },
+      { id: "users", label: "Users & Groups", icon: Users },
+      { id: "collection", label: "Collection", icon: SlidersHorizontal },
+      { id: "menu", label: "Menu", icon: Menu },
+      { id: "pages", label: "Pages", icon: FileText },
+      { id: "languages", label: "Languages", icon: Languages },
+      { id: "translations", label: "Translations", icon: Globe },
+      { id: "filters", label: "Filters", icon: Filter },
+      { id: "templates", label: "Templates", icon: LayoutTemplate },
+      { id: "thesauri", label: "Thesauri", icon: BookOpen },
+      { id: "relationship-types", label: "Relationship types", icon: Spline },
+      { id: "metadata-extraction", label: "Metadata Extraction", icon: ScanText },
+      { id: "paragraph-extraction", label: "Paragraph Extraction", icon: AlignLeft },
+    ],
+  },
+  {
+    id: "tools",
+    label: "Tools",
+    items: [
+      { id: "preserve", label: "Preserve", icon: Archive },
+      { id: "activitylog", label: "Activity log", icon: Activity },
+      { id: "customisation", label: "Global CSS & JS", icon: Code2 },
+      { id: "uploads", label: "Uploads", icon: Upload },
+      { id: "import-csv", label: "Import CSV", icon: FileSpreadsheet, navigateTo: "import-csv" },
+      {
+        id: "documentation",
+        label: "Documentation",
+        icon: ExternalLink,
+        external: "https://uwazi.io/page/9852italrtk/support",
+      },
+    ],
+  },
+];
+
+/** Flat lookup of every section item by id. */
+export const settingsItemsById: Record<string, SettingsItem> = Object.fromEntries(
+  settingsGroups.flatMap((g) => g.items.map((i) => [i.id, i])),
+);
+
+/** Which settings page is showing. Defaults to Account (Uwazi's first item).
+ *  Persisted so a reload keeps you on the same settings section. */
+export const settingsSectionAtom = atomWithStorage<string>("uwazi:settingsSection", "account");
+
+/** Mobile drill-in: on a phone the rail and the content can't share the width,
+ *  so we show one at a time. False = rail; true = the selected section (with a
+ *  back chevron). Ignored on desktop, where both panes render side by side.
+ *  Persisted so a mobile reload stays on the drilled-in section. */
+export const settingsMobileDrilledAtom = atomWithStorage<boolean>("uwazi:settingsDrilled", false);

--- a/app/src/components/files/DrawerFilesBody.tsx
+++ b/app/src/components/files/DrawerFilesBody.tsx
@@ -21,8 +21,13 @@ const KNOWN_LANGUAGES = ["EN", "ES", "FR", "AR", "PT", "DE", "—"];
  *  main Files view layout: one section per primary group with its
  *  translations beneath, then a flat Supporting files section. Used by both
  *  the Document tab drawer and the Metadata tab drawer so the file UI is
- *  consistent everywhere. */
-export function DrawerFilesBody() {
+ *  consistent everywhere. `hideActionBar` drops the bottom "Add file" footer
+ *  for hosts that supply their own (the library preview's Close / View bar). */
+export function DrawerFilesBody({
+  hideActionBar = false,
+}: {
+  hideActionBar?: boolean;
+} = {}) {
   const [files, setFiles] = useAtom(filesAtom);
   const groups = useAtomValue(documentGroupsAtom);
   const activeGroupId = useAtomValue(activePrimaryGroupIdAtom);
@@ -176,20 +181,22 @@ export function DrawerFilesBody() {
         )}
       </div>
 
-      <div
-        className="flex items-center gap-3 h-12 px-3 bg-paper shrink-0"
-        style={{ borderTop: "1px solid var(--border-primary)" }}
-      >
-        <button
-          onClick={() => setAddFileTarget({ mode: "new" })}
-          className="px-3 py-1.5 text-xs font-medium text-ink-secondary bg-warm hover:bg-parchment hover:text-ink rounded-md transition-colors cursor-pointer"
+      {!hideActionBar && (
+        <div
+          className="flex items-center gap-3 h-12 px-3 bg-paper shrink-0"
+          style={{ borderTop: "1px solid var(--border-primary)" }}
         >
-          Add file
-        </button>
-        <span className="text-xs text-ink-muted">
-          Learn more about <span className="font-bold underline">files</span>
-        </span>
-      </div>
+          <button
+            onClick={() => setAddFileTarget({ mode: "new" })}
+            className="px-3 py-1.5 text-xs font-medium text-ink-secondary bg-warm hover:bg-parchment hover:text-ink rounded-md transition-colors cursor-pointer"
+          >
+            Add file
+          </button>
+          <span className="text-xs text-ink-muted">
+            Learn more about <span className="font-bold underline">files</span>
+          </span>
+        </div>
+      )}
       <AddFileModal />
     </div>
   );

--- a/app/src/components/files/FileTable.tsx
+++ b/app/src/components/files/FileTable.tsx
@@ -27,6 +27,7 @@ import {
   viewerFileIdAtom,
 } from "../../atoms/files";
 import { Checkbox } from "../shared/Checkbox";
+import { DataTable, type Column } from "../shared/DataTable";
 import { formatFileDate } from "../../utils/dates";
 
 interface FileTableProps {
@@ -245,100 +246,66 @@ export function FileTable({
     );
   }
 
-  return (
-    <div
-      className="rounded-md overflow-hidden bg-paper"
-      style={{
-        boxShadow: "0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06)",
-      }}
-    >
-      {/* Header */}
-      <div
-        className="grid items-center gap-3 px-4 h-10 text-[11px] font-semibold text-ink-tertiary uppercase tracking-wider"
-        style={{
-          gridTemplateColumns: "28px 1fr 70px 70px 50px 90px 32px",
-          backgroundColor: "var(--bg-warm)",
-          borderBottom: "1px solid var(--border-primary)",
-        }}
-      >
-        <label className="flex items-center justify-center">
+  const columns: Column<FileEntry>[] = [
+    {
+      id: "select",
+      width: "28px",
+      align: "center",
+      header: (
+        <label className="flex items-center justify-center" onClick={(e) => e.stopPropagation()}>
+          <Checkbox checked={allSelected} onChange={onSelectAll} ariaLabel="Select all files" />
+        </label>
+      ),
+      cell: (file) => (
+        <label className="flex items-center justify-center" onClick={(e) => e.stopPropagation()}>
           <Checkbox
-            checked={allSelected}
-            onChange={onSelectAll}
-            ariaLabel="Select all files"
+            checked={selectedIds.has(file.id)}
+            onChange={() => onSelect(file.id)}
+            ariaLabel={`Select ${file.name}`}
           />
         </label>
-        <span>File name</span>
-        <span>Type</span>
-        <span>Size</span>
-        <span>Lang</span>
-        <span>Modified</span>
-        <span className="sr-only">Actions</span>
-      </div>
-
-      {/* Rows */}
-      {files.map((file) => {
-        const isSelected = selectedIds.has(file.id);
-        const isFocused = focusedId === file.id;
+      ),
+    },
+    {
+      id: "name",
+      header: "File name",
+      cell: (file) => {
         const Icon = typeIcons[file.type];
-
         return (
-          <div
-            key={file.id}
-            role="row"
-            tabIndex={0}
-            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onFocus?.(file.id); } }}
-            className={`grid items-center gap-3 px-4 h-11 text-sm transition-colors cursor-pointer
-              hover:bg-warm ${isFocused ? "bg-parchment" : ""}`}
-            style={{
-              gridTemplateColumns: "28px 1fr 70px 70px 50px 90px 32px",
-              borderBottom: "1px solid var(--border-primary)",
-            }}
-            onClick={() => onFocus?.(file.id)}
-          >
-            <label className="flex items-center justify-center" onClick={(e) => e.stopPropagation()}>
-              <Checkbox
-                checked={isSelected}
-                onChange={() => onSelect(file.id)}
-                ariaLabel={`Select ${file.name}`}
-              />
-            </label>
-
-            <div className="flex items-center gap-2 min-w-0">
-              <Icon size={14} className="text-ink-muted shrink-0" />
-              <span className="text-xs font-medium text-ink truncate">{file.name}</span>
-              {renderBadge(file)}
-            </div>
-
-            <span className="text-xs text-ink-tertiary">{typeLabels[file.type]}</span>
-            <span dir="ltr" className="text-xs text-ink-tertiary">{file.size}</span>
-            <span className="text-xs text-ink-tertiary">{file.language}</span>
-            <span className="text-xs text-ink-tertiary">
-              {formatFileDate(file.modified)}
-            </span>
-            <div
-              className="flex items-center justify-end"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {renderMenu(file)}
-            </div>
+          <div className="flex items-center gap-2 min-w-0">
+            <Icon size={14} className="text-ink-muted shrink-0" />
+            <span className="text-xs font-medium text-ink truncate">{file.name}</span>
+            {renderBadge(file)}
           </div>
         );
-      })}
-
-      {/* Footer */}
-      {!embedded && (
-        <div
-          className="flex items-center justify-between px-4 h-10 text-xs text-ink-muted"
-          style={{
-            backgroundColor: "var(--bg-warm)",
-            borderTop: "1px solid var(--border-primary)",
-          }}
-        >
-          <span>{files.length} files</span>
+      },
+    },
+    { id: "type", header: "Type", width: "70px", cell: (file) => <span className="text-xs text-ink-tertiary">{typeLabels[file.type]}</span> },
+    { id: "size", header: "Size", width: "70px", cell: (file) => <span dir="ltr" className="text-xs text-ink-tertiary">{file.size}</span> },
+    { id: "lang", header: "Lang", width: "50px", cell: (file) => <span className="text-xs text-ink-tertiary">{file.language}</span> },
+    { id: "modified", header: "Modified", width: "90px", cell: (file) => <span className="text-xs text-ink-tertiary">{formatFileDate(file.modified)}</span> },
+    {
+      id: "actions",
+      header: <span className="sr-only">Actions</span>,
+      width: "32px",
+      align: "right",
+      cell: (file) => (
+        <div className="flex items-center justify-end" onClick={(e) => e.stopPropagation()}>
+          {renderMenu(file)}
         </div>
-      )}
-    </div>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      data={files}
+      getRowId={(f) => f.id}
+      onRowClick={(f) => onFocus?.(f.id)}
+      isRowSelected={(f) => focusedId === f.id}
+      footer={embedded ? undefined : <span>{files.length} files</span>}
+    />
   );
 }
 

--- a/app/src/components/layout/DrawerTabs.tsx
+++ b/app/src/components/layout/DrawerTabs.tsx
@@ -8,12 +8,15 @@ interface DrawerTabsProps {
   tabs: DrawerTab[];
   activeId: string;
   onChange: (id: string) => void;
+  /** Wrapper padding — defaults to the drawer's `px-3 py-2`. Pass e.g. `""`
+   *  to render flush within a page body that owns its own padding. */
+  className?: string;
 }
 
-export function DrawerTabs({ tabs, activeId, onChange }: DrawerTabsProps) {
+export function DrawerTabs({ tabs, activeId, onChange, className = "px-3 py-2" }: DrawerTabsProps) {
   return (
     <div
-      className="px-3 py-2 shrink-0 overflow-x-auto no-scrollbar"
+      className={`${className} shrink-0 overflow-x-auto no-scrollbar`}
     >
       <div
         className="flex items-stretch rounded-md overflow-hidden w-fit"

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -242,11 +242,17 @@ export function Navbar({ onLogoClick, appView = "entity", onNavigate, theme, onT
                     </div>
                     <Languages size={14} className="text-ink-tertiary" />
                   </button>
-                  <button className="flex items-center justify-between w-full px-3 py-2 text-xs font-medium text-ink-secondary hover:bg-warm transition-colors">
+                  <button
+                    onClick={() => { onNavigate?.("settings"); setSettingsOpen(false); }}
+                    className="flex items-center justify-between w-full px-3 py-2 text-xs font-medium text-ink-secondary hover:bg-warm transition-colors"
+                  >
                     User settings
                     <User size={14} className="text-ink-tertiary" />
                   </button>
-                  <button className="flex items-center justify-between w-full px-3 py-2 text-xs font-medium text-ink-secondary hover:bg-warm transition-colors">
+                  <button
+                    onClick={() => { onNavigate?.("settings"); setSettingsOpen(false); }}
+                    className="flex items-center justify-between w-full px-3 py-2 text-xs font-medium text-ink-secondary hover:bg-warm transition-colors"
+                  >
                     System settings
                     <Server size={14} className="text-ink-tertiary" />
                   </button>
@@ -349,11 +355,17 @@ export function Navbar({ onLogoClick, appView = "entity", onNavigate, theme, onT
                 {rtl ? "ON" : "OFF"}
               </span>
             </button>
-            <button className="flex items-center gap-3 w-full px-4 py-3 text-sm font-medium text-ink-secondary hover:bg-warm transition-colors">
+            <button
+              onClick={() => { onNavigate?.("settings"); setMobileMenuOpen(false); }}
+              className="flex items-center gap-3 w-full px-4 py-3 text-sm font-medium text-ink-secondary hover:bg-warm transition-colors"
+            >
               <User size={16} className="text-ink-tertiary" />
               User settings
             </button>
-            <button className="flex items-center gap-3 w-full px-4 py-3 text-sm font-medium text-ink-secondary hover:bg-warm transition-colors">
+            <button
+              onClick={() => { onNavigate?.("settings"); setMobileMenuOpen(false); }}
+              className="flex items-center gap-3 w-full px-4 py-3 text-sm font-medium text-ink-secondary hover:bg-warm transition-colors"
+            >
               <Server size={16} className="text-ink-tertiary" />
               System settings
             </button>

--- a/app/src/components/library/EntityDrawerPreview.tsx
+++ b/app/src/components/library/EntityDrawerPreview.tsx
@@ -58,13 +58,9 @@ export function EntityDrawerPreview({ entityId }: { entityId: string }) {
 
   return (
     <div className="flex flex-col h-full min-h-0 bg-paper">
-      {/* Main-tab navigation on top — mirrors the entity view so the divider
-          beneath it lines up with the library toolbar's. Compact: no language
-          switcher / back button. */}
-      <MainTabs tabs={tabs} activeId={activeTab} onChange={setActiveTab} />
-
-      {/* Title row — same height (h-10) and divider as the entity view's
-          DocMeta. Carries the close affordance back to the filters list. */}
+      {/* Identity header on top — the entity title + close, acting as the
+          panel header. Tabs sit beneath it (flipped from the entity view so the
+          drawer reads title-first). */}
       <div
         className="flex items-center gap-2 h-10 px-3 shrink-0"
         style={{ borderBottom: "1px solid var(--border-primary)" }}
@@ -85,14 +81,17 @@ export function EntityDrawerPreview({ entityId }: { entityId: string }) {
         </button>
       </div>
 
+      {/* Main-tab navigation beneath the identity header. */}
+      <MainTabs tabs={tabs} activeId={activeTab} onChange={setActiveTab} />
+
       {/* Tab content — drawer-flavoured bodies, scoped to the focused entity. */}
       <div className="flex-1 min-h-0 relative overflow-hidden">
         {activeTab === "document" ? (
-          <DocumentViewer showMinimap={false} />
+          <DocumentViewer showMinimap={false} hideActionBar />
         ) : activeTab === "relationships" ? (
-          <RelationshipsDrawerSection />
+          <RelationshipsDrawerSection hideActionBar />
         ) : activeTab === "files" ? (
-          <DrawerFilesBody />
+          <DrawerFilesBody hideActionBar />
         ) : (
           <MetadataSummary language={language} entityId={entityId} />
         )}

--- a/app/src/components/relationships/RelationshipsDrawerSection.tsx
+++ b/app/src/components/relationships/RelationshipsDrawerSection.tsx
@@ -28,8 +28,14 @@ import { RelationshipsActionBar } from "./RelationshipsActionBar";
 
 /** Drawer-style connections section: toolbar + body + scoped filters drawer.
  *  Used wherever the unified Relationships panel needs to render inside a
- *  drawer (ReferencePanel sub-tab, MetadataView's relationships tab, etc.). */
-export function RelationshipsDrawerSection() {
+ *  drawer (ReferencePanel sub-tab, MetadataView's relationships tab, etc.).
+ *  `hideActionBar` drops the bottom RelationshipsActionBar for hosts that
+ *  supply their own footer (the library preview's Close / View entity bar). */
+export function RelationshipsDrawerSection({
+  hideActionBar = false,
+}: {
+  hideActionBar?: boolean;
+} = {}) {
   const [, setReferences] = useAtom(scopedReferencesAtom);
   const [, setToasts] = useAtom(toastsAtom);
   const [, setSearchQuery] = useAtom(searchQueryAtom);
@@ -105,7 +111,7 @@ export function RelationshipsDrawerSection() {
         </div>
       </div>
       <RelationshipsPanelBody onDelete={handleDelete} />
-      <RelationshipsActionBar compact />
+      {!hideActionBar && <RelationshipsActionBar compact />}
 
       <FiltersDrawer
         open={filtersOpen}

--- a/app/src/components/settings/Button.tsx
+++ b/app/src/components/settings/Button.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
-type Variant = "primary" | "secondary" | "danger" | "ghost";
+type Variant = "primary" | "secondary" | "danger" | "ghost" | "success";
 type Size = "sm" | "md";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -18,6 +18,8 @@ const variants: Record<Variant, string> = {
   secondary: "bg-warm text-ink-secondary hover:bg-parchment hover:text-ink",
   danger: "bg-seal text-white hover:bg-seal/90",
   ghost: "text-ink-secondary hover:bg-warm hover:text-ink",
+  // Active save affordance — green only once there's an unsaved change.
+  success: "bg-success text-white hover:bg-success/90",
 };
 
 // Padding-based, matching the app's hand-rolled pills (ToolsActionBar /

--- a/app/src/components/settings/Button.tsx
+++ b/app/src/components/settings/Button.tsx
@@ -1,0 +1,58 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type Variant = "primary" | "secondary" | "danger" | "ghost";
+type Size = "sm" | "md";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+  icon?: ReactNode;
+  children?: ReactNode;
+}
+
+const variants: Record<Variant, string> = {
+  // The canonical action-bar button (the Translations page's "Translate" /
+  // "Import" buttons) — calm warm fill, ink-secondary text. Used for every
+  // action-bar action. Seal stays for danger only.
+  primary: "bg-warm text-ink-secondary hover:bg-parchment hover:text-ink",
+  secondary: "bg-warm text-ink-secondary hover:bg-parchment hover:text-ink",
+  danger: "bg-seal text-white hover:bg-seal/90",
+  ghost: "text-ink-secondary hover:bg-warm hover:text-ink",
+};
+
+// Padding-based, matching the app's hand-rolled pills (ToolsActionBar /
+// CreateRelationshipModal) — not fixed heights.
+const sizes: Record<Size, string> = {
+  sm: "px-3 py-1.5 text-xs gap-1.5",
+  md: "px-4 py-2 text-sm gap-2",
+};
+
+/** Settings-scoped button. We don't have a global Button primitive (every
+ *  other surface hand-rolls inline pills), so this keeps the many cloned
+ *  settings views consistent without touching the rest of the app. */
+// Flat, calm disabled state — a vellum chip rather than translucent ink
+// (which goes muddy-grey over a paper footer). Replaces the variant fill.
+const disabledClass = "bg-vellum text-ink-muted cursor-not-allowed";
+
+export function Button({
+  variant = "secondary",
+  size = "md",
+  icon,
+  children,
+  className = "",
+  disabled,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      disabled={disabled}
+      className={`inline-flex items-center justify-center font-medium rounded-md transition-colors ${
+        disabled ? disabledClass : `cursor-pointer ${variants[variant]}`
+      } ${sizes[size]} ${className}`}
+      {...props}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}

--- a/app/src/components/settings/Field.tsx
+++ b/app/src/components/settings/Field.tsx
@@ -1,0 +1,36 @@
+import type { InputHTMLAttributes, ReactNode } from "react";
+
+/** Labelled form field wrapper for settings forms. */
+export function Field({
+  label,
+  hint,
+  error,
+  children,
+}: {
+  label?: string;
+  hint?: string;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      {label && <span className="text-xs font-medium text-ink-secondary">{label}</span>}
+      {children}
+      {error ? (
+        <span className="text-xs text-seal">{error}</span>
+      ) : hint ? (
+        <span className="text-xs text-ink-tertiary">{hint}</span>
+      ) : null}
+    </label>
+  );
+}
+
+/** Text input styled to our tokens — warm field, carbon focus ring. */
+export function TextInput({ className = "", ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={`w-full px-3 py-2 text-sm text-ink bg-warm border border-border rounded-md placeholder:text-ink-muted focus:outline-none focus:ring-2 focus:ring-carbon/20 focus:border-carbon/40 transition-colors ${className}`}
+      {...props}
+    />
+  );
+}

--- a/app/src/components/settings/RowActions.tsx
+++ b/app/src/components/settings/RowActions.tsx
@@ -1,0 +1,32 @@
+import { Pencil, Trash2 } from "lucide-react";
+
+/** Edit + delete icon buttons for a table row — the recurring action pair
+ *  across the settings list views. */
+export function RowActions({
+  label,
+  onEdit,
+  onDelete,
+}: {
+  label: string;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-end gap-1">
+      <button
+        onClick={(e) => { e.stopPropagation(); onEdit?.(); }}
+        aria-label={`Edit ${label}`}
+        className="p-1.5 rounded-md text-ink-tertiary hover:bg-warm hover:text-ink transition-colors cursor-pointer"
+      >
+        <Pencil size={14} />
+      </button>
+      <button
+        onClick={(e) => { e.stopPropagation(); onDelete?.(); }}
+        aria-label={`Delete ${label}`}
+        className="p-1.5 rounded-md text-ink-tertiary hover:bg-seal-tint hover:text-seal transition-colors cursor-pointer"
+      >
+        <Trash2 size={14} />
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/settings/SettingsContent.tsx
+++ b/app/src/components/settings/SettingsContent.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from "react";
+import { useSetAtom } from "jotai";
+import { ChevronLeft } from "lucide-react";
+import { settingsMobileDrilledAtom } from "../../atoms/settings";
+
+/** Content-area shell for a settings page, mirroring Uwazi's V2
+ *  SettingsContent layout (Header breadcrumb · Body · sticky Footer save bar)
+ *  but rendered with our tokens. Compose as:
+ *
+ *    <SettingsContent>
+ *      <SettingsContent.Header title="Languages" right={<Button/>} />
+ *      <SettingsContent.Body>…</SettingsContent.Body>
+ *      <SettingsContent.Footer>…</SettingsContent.Footer>
+ *    </SettingsContent>
+ */
+export function SettingsContent({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col h-full min-h-0 bg-paper" data-testid="settings-content">
+      {children}
+    </div>
+  );
+}
+
+interface HeaderProps {
+  /** Breadcrumb trail before the title (e.g. ["Templates"]). */
+  path?: string[];
+  title: ReactNode;
+}
+
+// Title/breadcrumb only — actions live in the bottom action bar (Footer), per
+// our convention (we don't put primary actions in a top bar).
+SettingsContent.Header = function SettingsHeader({ path, title }: HeaderProps) {
+  const setDrilled = useSetAtom(settingsMobileDrilledAtom);
+  return (
+    <div
+      className="flex items-center gap-2 h-12 px-4 shrink-0 bg-paper"
+      style={{ borderBottom: "1px solid var(--border-primary)" }}
+      data-testid="settings-content-header"
+    >
+      <button
+        onClick={() => setDrilled(false)}
+        aria-label="Back to settings"
+        className="md:hidden -ms-1 p-1 rounded-md text-ink-tertiary hover:bg-warm hover:text-ink transition-colors shrink-0"
+      >
+        <ChevronLeft size={18} />
+      </button>
+      <div className="flex items-center gap-1.5 min-w-0 flex-1 text-sm">
+        {path?.map((crumb) => (
+          <span key={crumb} className="flex items-center gap-1.5 text-ink-tertiary">
+            <span className="truncate">{crumb}</span>
+            <span className="text-ink-muted">/</span>
+          </span>
+        ))}
+        <span className="font-semibold text-ink truncate">{title}</span>
+      </div>
+    </div>
+  );
+};
+
+SettingsContent.Body = function SettingsBody({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`grow min-h-0 overflow-auto px-4 py-4 ${className}`}
+      data-testid="settings-content-body"
+    >
+      {children}
+    </div>
+  );
+};
+
+SettingsContent.Footer = function SettingsFooter({
+  children,
+  highlighted = false,
+}: {
+  children: ReactNode;
+  highlighted?: boolean;
+}) {
+  return (
+    <div
+      className={`sticky bottom-0 z-10 flex items-center gap-2 h-12 px-4 shrink-0 ${
+        highlighted ? "bg-carbon-tint" : "bg-paper"
+      }`}
+      style={{ borderTop: "1px solid var(--border-primary)" }}
+      data-testid="settings-content-footer"
+    >
+      {children}
+    </div>
+  );
+};

--- a/app/src/components/settings/SettingsContent.tsx
+++ b/app/src/components/settings/SettingsContent.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useSetAtom } from "jotai";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, ArrowLeft } from "lucide-react";
 import { settingsMobileDrilledAtom } from "../../atoms/settings";
 
 /** Content-area shell for a settings page, mirroring Uwazi's V2
@@ -25,11 +25,14 @@ interface HeaderProps {
   /** Breadcrumb trail before the title (e.g. ["Templates"]). */
   path?: string[];
   title: ReactNode;
+  /** Provided by a nested (child) view — renders a back arrow on all sizes and
+   *  makes the breadcrumb crumbs clickable, all returning to the parent list. */
+  onBack?: () => void;
 }
 
 // Title/breadcrumb only — actions live in the bottom action bar (Footer), per
 // our convention (we don't put primary actions in a top bar).
-SettingsContent.Header = function SettingsHeader({ path, title }: HeaderProps) {
+SettingsContent.Header = function SettingsHeader({ path, title, onBack }: HeaderProps) {
   const setDrilled = useSetAtom(settingsMobileDrilledAtom);
   return (
     <div
@@ -37,20 +40,44 @@ SettingsContent.Header = function SettingsHeader({ path, title }: HeaderProps) {
       style={{ borderBottom: "1px solid var(--border-primary)" }}
       data-testid="settings-content-header"
     >
-      <button
-        onClick={() => setDrilled(false)}
-        aria-label="Back to settings"
-        className="md:hidden -ms-1 p-1 rounded-md text-ink-tertiary hover:bg-warm hover:text-ink transition-colors shrink-0"
-      >
-        <ChevronLeft size={18} />
-      </button>
+      {onBack ? (
+        // Nested view: a back arrow on every breakpoint → returns to the list.
+        <button
+          onClick={onBack}
+          aria-label="Back"
+          className="-ms-1 p-1 rounded-md text-ink-tertiary hover:bg-warm hover:text-ink transition-colors shrink-0"
+        >
+          <ArrowLeft size={18} />
+        </button>
+      ) : (
+        // Top-level page: the mobile drill-out to the settings rail.
+        <button
+          onClick={() => setDrilled(false)}
+          aria-label="Back to settings"
+          className="md:hidden -ms-1 p-1 rounded-md text-ink-tertiary hover:bg-warm hover:text-ink transition-colors shrink-0"
+        >
+          <ChevronLeft size={18} />
+        </button>
+      )}
       <div className="flex items-center gap-1.5 min-w-0 flex-1 text-sm">
-        {path?.map((crumb) => (
-          <span key={crumb} className="flex items-center gap-1.5 text-ink-tertiary">
-            <span className="truncate">{crumb}</span>
-            <span className="text-ink-muted">/</span>
-          </span>
-        ))}
+        {path?.map((crumb) =>
+          onBack ? (
+            <span key={crumb} className="flex items-center gap-1.5">
+              <button
+                onClick={onBack}
+                className="truncate text-ink-tertiary hover:text-ink hover:underline transition-colors cursor-pointer"
+              >
+                {crumb}
+              </button>
+              <span className="text-ink-muted">/</span>
+            </span>
+          ) : (
+            <span key={crumb} className="flex items-center gap-1.5 text-ink-tertiary">
+              <span className="truncate">{crumb}</span>
+              <span className="text-ink-muted">/</span>
+            </span>
+          ),
+        )}
         <span className="font-semibold text-ink truncate">{title}</span>
       </div>
     </div>
@@ -83,7 +110,7 @@ SettingsContent.Footer = function SettingsFooter({
 }) {
   return (
     <div
-      className={`sticky bottom-0 z-10 flex items-center gap-2 h-12 px-4 shrink-0 ${
+      className={`sticky bottom-0 z-10 flex items-center justify-end gap-2 h-12 px-4 shrink-0 ${
         highlighted ? "bg-carbon-tint" : "bg-paper"
       }`}
       style={{ borderTop: "1px solid var(--border-primary)" }}

--- a/app/src/components/settings/SettingsNav.tsx
+++ b/app/src/components/settings/SettingsNav.tsx
@@ -1,0 +1,73 @@
+import { useAtom, useSetAtom } from "jotai";
+import { ExternalLink } from "lucide-react";
+import { settingsGroups, settingsSectionAtom, settingsMobileDrilledAtom } from "../../atoms/settings";
+import type { AppView } from "../../atoms/navigation";
+
+/** The settings rail — three grouped sections (User / System / Tools) matching
+ *  Uwazi's V2 SettingsNavigation. Styled to the entity-view ToolsSidebar:
+ *  full-width items, px-5 py-2, active = bg-warm text-ink (no rounded inset). */
+export function SettingsNav({ onNavigate }: { onNavigate?: (view: AppView) => void }) {
+  const [section, setSection] = useAtom(settingsSectionAtom);
+  const setDrilled = useSetAtom(settingsMobileDrilledAtom);
+
+  return (
+    <nav
+      aria-label="Settings navigation"
+      className="h-full w-full md:w-[15.625rem] shrink-0 overflow-y-auto bg-paper py-4"
+      style={{ borderRight: "1px solid var(--border-primary)" }}
+    >
+      {settingsGroups.map((group) => (
+        <div key={group.id} className="mb-2">
+          {group.label && (
+            <h3 className="px-5 py-2 text-[10px] font-semibold uppercase tracking-wider text-ink-muted">
+              {group.label}
+            </h3>
+          )}
+          {group.items.map((item) => {
+            const Icon = item.icon;
+            const active = section === item.id && !item.navigateTo && !item.external;
+
+            const inner = (
+              <>
+                <Icon size={15} className="text-ink-tertiary shrink-0" />
+                <span className="truncate flex-1">{item.label}</span>
+                {item.badge && (
+                  <span className="text-[10px] font-semibold text-carbon">{item.badge}</span>
+                )}
+                {item.external && <ExternalLink size={12} className="text-ink-muted shrink-0" />}
+              </>
+            );
+
+            const cls = `flex items-center gap-2.5 w-full px-5 py-2 text-[13px] font-medium text-left transition-colors ${
+              active ? "bg-warm text-ink" : "text-ink-secondary hover:bg-warm hover:text-ink"
+            }`;
+
+            if (item.external) {
+              return (
+                <a key={item.id} href={item.external} target="_blank" rel="noopener noreferrer" className={cls}>
+                  {inner}
+                </a>
+              );
+            }
+
+            return (
+              <button
+                key={item.id}
+                className={cls}
+                onClick={() => {
+                  if (item.navigateTo) onNavigate?.(item.navigateTo);
+                  else {
+                    setSection(item.id);
+                    setDrilled(true); // mobile: reveal the section (ignored on desktop)
+                  }
+                }}
+              >
+                {inner}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/app/src/components/settings/StatusPill.tsx
+++ b/app/src/components/settings/StatusPill.tsx
@@ -1,0 +1,16 @@
+import type { ExtractorStatus } from "../../data/settings";
+
+const styles: Record<ExtractorStatus, { cls: string; label: string }> = {
+  ready: { cls: "bg-success-light text-success", label: "Ready" },
+  training: { cls: "bg-carbon-tint text-carbon", label: "Training" },
+  processing: { cls: "bg-warning-light text-warning", label: "Processing" },
+  error: { cls: "bg-seal-tint text-seal", label: "Error" },
+};
+
+/** Status badge for extraction / processing jobs, on our semantic tints. */
+export function StatusPill({ status }: { status: ExtractorStatus }) {
+  const { cls, label } = styles[status];
+  return (
+    <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-md w-fit ${cls}`}>{label}</span>
+  );
+}

--- a/app/src/components/settings/Table.tsx
+++ b/app/src/components/settings/Table.tsx
@@ -1,0 +1,39 @@
+import { DataTable, type Column } from "../shared/DataTable";
+
+export type { Column };
+
+interface TableProps<T> {
+  columns: Column<T>[];
+  data: T[];
+  getRowId: (row: T) => string;
+  onRowClick?: (row: T) => void;
+  selectedId?: string | null;
+  emptyState?: React.ReactNode;
+}
+
+/** Settings list table — the shared `DataTable` (entity-view Files style) with
+ *  a rem-based min-width so wide settings tables scroll horizontally on narrow
+ *  panes instead of squishing. Kept as a thin wrapper so the many settings
+ *  pages keep importing `{ Table, Column }` from here unchanged. */
+export function Table<T>({ columns, data, getRowId, onRowClick, selectedId, emptyState }: TableProps<T>) {
+  // Flexible columns counted at a ~9rem floor, + gaps + padding.
+  const minWidthRem =
+    columns.reduce((sum, c) => {
+      const rem = c.width && c.width.endsWith("rem") ? parseFloat(c.width) : NaN;
+      return sum + (Number.isNaN(rem) ? 9 : rem);
+    }, 0) +
+    (columns.length - 1) * 0.75 +
+    2;
+
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      getRowId={getRowId}
+      onRowClick={onRowClick}
+      isRowSelected={selectedId != null ? (row) => getRowId(row) === selectedId : undefined}
+      emptyState={emptyState}
+      minWidthRem={minWidthRem}
+    />
+  );
+}

--- a/app/src/components/settings/pages/AccountPage.tsx
+++ b/app/src/components/settings/pages/AccountPage.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { ShieldCheck } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field, TextInput } from "../Field";
+import { currentAccount } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+export function AccountPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [email, setEmail] = useState(currentAccount.email);
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+
+  const dirty = email !== currentAccount.email || password.length > 0;
+  const mismatch = password.length > 0 && confirm.length > 0 && password !== confirm;
+
+  const save = () => {
+    setPassword("");
+    setConfirm("");
+    setToasts((prev) => [
+      ...prev,
+      { id: Date.now().toString(), message: "Account updated", type: "success" as const },
+    ]);
+  };
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Account" />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6">
+          <section>
+            <h3 className="text-sm font-semibold text-ink mb-1">Email</h3>
+            <p className="text-xs text-ink-tertiary mb-3">
+              The address you use to sign in and receive notifications.
+            </p>
+            <Field label="Email">
+              <TextInput type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            </Field>
+          </section>
+
+          <section className="pt-6" style={{ borderTop: "1px solid var(--border-soft)" }}>
+            <h3 className="text-sm font-semibold text-ink mb-1">Change password</h3>
+            <p className="text-xs text-ink-tertiary mb-3">
+              Leave blank to keep your current password.
+            </p>
+            <div className="grid sm:grid-cols-2 gap-3">
+              <Field label="New password">
+                <TextInput
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                />
+              </Field>
+              <Field label="Confirm password" error={mismatch ? "Passwords don't match" : undefined}>
+                <TextInput
+                  type="password"
+                  value={confirm}
+                  onChange={(e) => setConfirm(e.target.value)}
+                  placeholder="••••••••"
+                />
+              </Field>
+            </div>
+          </section>
+
+          <section className="pt-6" style={{ borderTop: "1px solid var(--border-soft)" }}>
+            <h3 className="text-sm font-semibold text-ink mb-3">Two-factor authentication</h3>
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-paper px-4 py-3">
+              <span className="flex items-center justify-center w-8 h-8 rounded-md bg-success-light shrink-0">
+                <ShieldCheck size={16} className="text-success" />
+              </span>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-ink">2FA is enabled</p>
+                <p className="text-xs text-ink-tertiary">
+                  Your account is protected with an authenticator app.
+                </p>
+              </div>
+              <Button variant="secondary" size="sm">
+                Manage
+              </Button>
+            </div>
+          </section>
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" disabled={!dirty || mismatch} onClick={save}>
+          Update account
+        </Button>
+        {dirty && <span className="text-xs text-ink-tertiary">Unsaved changes</span>}
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/AccountPage.tsx
+++ b/app/src/components/settings/pages/AccountPage.tsx
@@ -85,10 +85,10 @@ export function AccountPage() {
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" disabled={!dirty || mismatch} onClick={save}>
+        {dirty && <span className="text-xs text-ink-tertiary me-auto">Unsaved changes</span>}
+        <Button variant="success" size="sm" disabled={!dirty || mismatch} onClick={save}>
           Update account
         </Button>
-        {dirty && <span className="text-xs text-ink-tertiary">Unsaved changes</span>}
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/ActivityLogPage.tsx
+++ b/app/src/components/settings/pages/ActivityLogPage.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { Search, X } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Table, type Column } from "../Table";
+import { seedActivityLog, type SettingsLogEntry, type LogMethod } from "../../../data/settings";
+
+const methodStyle: Record<LogMethod, string> = {
+  CREATE: "bg-success-light text-success",
+  UPDATE: "bg-carbon-tint text-carbon",
+  DELETE: "bg-seal-tint text-seal",
+  MIGRATE: "bg-warning-light text-warning",
+};
+
+export function ActivityLogPage() {
+  const [query, setQuery] = useState("");
+
+  const filtered = seedActivityLog.filter((e) =>
+    `${e.user} ${e.method} ${e.summary}`.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  const columns: Column<SettingsLogEntry>[] = [
+    {
+      id: "method",
+      header: "Action",
+      width: "7rem",
+      cell: (e) => (
+        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-md w-fit ${methodStyle[e.method]}`}>
+          {e.method}
+        </span>
+      ),
+    },
+    {
+      id: "summary",
+      header: "Summary",
+      cell: (e) => <span className="text-ink truncate">{e.summary}</span>,
+    },
+    {
+      id: "user",
+      header: "User",
+      width: "8rem",
+      cell: (e) => <span className="text-ink-secondary truncate">{e.user}</span>,
+    },
+    {
+      id: "time",
+      header: "Time",
+      width: "11rem",
+      cell: (e) => <span dir="ltr" className="text-xs text-ink-tertiary tabular-nums">{e.time}</span>,
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Activity log" />
+      <SettingsContent.Body>
+        <div className="relative mb-4 max-w-sm">
+          <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-muted" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search activity…"
+            className="w-full pl-8 pr-8 py-2 text-sm text-ink bg-warm border border-border rounded-md placeholder:text-ink-muted focus:outline-none focus:ring-2 focus:ring-carbon/20"
+          />
+          {query && (
+            <button
+              onClick={() => setQuery("")}
+              aria-label="Clear search"
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded-full hover:bg-parchment text-ink-muted hover:text-ink cursor-pointer"
+            >
+              <X size={12} />
+            </button>
+          )}
+        </div>
+        <Table
+          columns={columns}
+          data={filtered}
+          getRowId={(e) => e.id}
+          emptyState="No activity matches your search."
+        />
+      </SettingsContent.Body>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/CollectionPage.tsx
+++ b/app/src/components/settings/pages/CollectionPage.tsx
@@ -38,6 +38,14 @@ export function CollectionPage() {
   const [cookiePolicy, setCookiePolicy] = useState(true);
   const [publicSharing, setPublicSharing] = useState(true);
 
+  const dirty =
+    name !== "Inter-American Human Rights Archive" ||
+    landing !== "/library" ||
+    defaultView !== "cards" ||
+    privateInstance !== false ||
+    cookiePolicy !== true ||
+    publicSharing !== true;
+
   const save = () =>
     setToasts((p) => [...p, { id: Date.now().toString(), message: "Collection settings saved", type: "success" as const }]);
 
@@ -96,7 +104,7 @@ export function CollectionPage() {
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" onClick={save}>
+        <Button variant="success" size="sm" disabled={!dirty} onClick={save}>
           Save
         </Button>
       </SettingsContent.Footer>

--- a/app/src/components/settings/pages/CollectionPage.tsx
+++ b/app/src/components/settings/pages/CollectionPage.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field, TextInput } from "../Field";
+import { RadioGroup } from "../../shared/RadioGroup";
+import { Checkbox } from "../../shared/Checkbox";
+import { LayoutGrid, Table2, Map } from "lucide-react";
+import { toastsAtom } from "../../../atoms/references";
+
+interface ToggleRowProps {
+  label: string;
+  hint: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}
+
+function ToggleRow({ label, hint, checked, onChange }: ToggleRowProps) {
+  return (
+    <label className="flex items-start gap-3 rounded-lg border border-border bg-paper px-4 py-3 cursor-pointer">
+      <span className="pt-0.5">
+        <Checkbox checked={checked} onChange={(e) => onChange(e.target.checked)} ariaLabel={label} />
+      </span>
+      <span className="min-w-0">
+        <span className="block text-sm font-medium text-ink">{label}</span>
+        <span className="block text-xs text-ink-tertiary">{hint}</span>
+      </span>
+    </label>
+  );
+}
+
+export function CollectionPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [name, setName] = useState("Inter-American Human Rights Archive");
+  const [landing, setLanding] = useState("/library");
+  const [defaultView, setDefaultView] = useState("cards");
+  const [privateInstance, setPrivateInstance] = useState(false);
+  const [cookiePolicy, setCookiePolicy] = useState(true);
+  const [publicSharing, setPublicSharing] = useState(true);
+
+  const save = () =>
+    setToasts((p) => [...p, { id: Date.now().toString(), message: "Collection settings saved", type: "success" as const }]);
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Collection" />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6">
+          <section className="grid sm:grid-cols-2 gap-3">
+            <Field label="Collection name">
+              <TextInput value={name} onChange={(e) => setName(e.target.value)} />
+            </Field>
+            <Field label="Custom landing page" hint="Where visitors land first.">
+              <TextInput value={landing} onChange={(e) => setLanding(e.target.value)} />
+            </Field>
+          </section>
+
+          <section className="pt-6" style={{ borderTop: "1px solid var(--border-soft)" }}>
+            <h3 className="text-sm font-semibold text-ink mb-1">Default library view</h3>
+            <p className="text-xs text-ink-tertiary mb-3">How the library shows results by default.</p>
+            <RadioGroup
+              name="default-view"
+              ariaLabel="Default library view"
+              inline
+              value={defaultView}
+              onChange={setDefaultView}
+              options={[
+                { id: "cards", label: "Cards", hint: "Visual entity cards", icon: <LayoutGrid size={14} className="text-ink-tertiary" /> },
+                { id: "table", label: "Table", hint: "Dense rows", icon: <Table2 size={14} className="text-ink-tertiary" /> },
+                { id: "map", label: "Map", hint: "Geographic", icon: <Map size={14} className="text-ink-tertiary" /> },
+              ]}
+            />
+          </section>
+
+          <section className="pt-6 flex flex-col gap-2" style={{ borderTop: "1px solid var(--border-soft)" }}>
+            <h3 className="text-sm font-semibold text-ink mb-1">Access</h3>
+            <ToggleRow
+              label="Private instance"
+              hint="Only logged-in users can see the collection."
+              checked={privateInstance}
+              onChange={setPrivateInstance}
+            />
+            <ToggleRow
+              label="Show cookie policy"
+              hint="Display a cookie consent banner to visitors."
+              checked={cookiePolicy}
+              onChange={setCookiePolicy}
+            />
+            <ToggleRow
+              label="Allow public sharing"
+              hint="Let visitors share entity links on social media."
+              checked={publicSharing}
+              onChange={setPublicSharing}
+            />
+          </section>
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" onClick={save}>
+          Save
+        </Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/CustomisationPage.tsx
+++ b/app/src/components/settings/pages/CustomisationPage.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { DrawerTabs } from "../../layout/DrawerTabs";
+import { toastsAtom } from "../../../atoms/references";
+
+const SAMPLE_CSS = `/* Global CSS — applied across the public collection */
+.home-banner {
+  background: var(--bg-parchment);
+}`;
+
+const SAMPLE_JS = `// Global JS — runs on every public page
+console.log('Collection loaded');`;
+
+export function CustomisationPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [lang, setLang] = useState<"css" | "js">("css");
+  const [css, setCss] = useState(SAMPLE_CSS);
+  const [js, setJs] = useState(SAMPLE_JS);
+
+  const save = () =>
+    setToasts((p) => [...p, { id: Date.now().toString(), message: "Customisation saved", type: "success" as const }]);
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Global CSS & JS" />
+      <SettingsContent.Body className="flex flex-col min-h-0">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-3">
+          <p className="text-xs text-ink-tertiary">
+            Custom styles and scripts injected into the public-facing collection.
+          </p>
+          <DrawerTabs
+            className=""
+            activeId={lang}
+            onChange={(v) => setLang(v as "css" | "js")}
+            tabs={[
+              { id: "css", label: "CSS" },
+              { id: "js", label: "JS" },
+            ]}
+          />
+        </div>
+        <textarea
+          value={lang === "css" ? css : js}
+          onChange={(e) => (lang === "css" ? setCss(e.target.value) : setJs(e.target.value))}
+          spellCheck={false}
+          dir="ltr"
+          className="flex-1 min-h-[20rem] w-full p-4 text-sm font-mono text-ink bg-warm border border-border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-carbon/20"
+        />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" onClick={save}>
+          Save
+        </Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/CustomisationPage.tsx
+++ b/app/src/components/settings/pages/CustomisationPage.tsx
@@ -19,6 +19,8 @@ export function CustomisationPage() {
   const [css, setCss] = useState(SAMPLE_CSS);
   const [js, setJs] = useState(SAMPLE_JS);
 
+  const dirty = css !== SAMPLE_CSS || js !== SAMPLE_JS;
+
   const save = () =>
     setToasts((p) => [...p, { id: Date.now().toString(), message: "Customisation saved", type: "success" as const }]);
 
@@ -49,7 +51,7 @@ export function CustomisationPage() {
         />
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" onClick={save}>
+        <Button variant="success" size="sm" disabled={!dirty} onClick={save}>
           Save
         </Button>
       </SettingsContent.Footer>

--- a/app/src/components/settings/pages/DashboardPage.tsx
+++ b/app/src/components/settings/pages/DashboardPage.tsx
@@ -1,0 +1,54 @@
+import { SettingsContent } from "../SettingsContent";
+import { StatsCard } from "../../shared/StatsCard";
+import { Table, type Column } from "../Table";
+import { entities } from "../../../data/entities";
+import {
+  seedUsers,
+  seedLanguages,
+  seedRelationTypes,
+  seedActivityLog,
+  type SettingsLogEntry,
+  type LogMethod,
+} from "../../../data/settings";
+
+const methodStyle: Record<LogMethod, string> = {
+  CREATE: "bg-success-light text-success",
+  UPDATE: "bg-carbon-tint text-carbon",
+  DELETE: "bg-seal-tint text-seal",
+  MIGRATE: "bg-warning-light text-warning",
+};
+
+export function DashboardPage() {
+  const connectionTotal = seedRelationTypes.reduce((n, r) => n + r.usageCount, 0);
+
+  const columns: Column<SettingsLogEntry>[] = [
+    {
+      id: "method",
+      header: "Action",
+      width: "7rem",
+      cell: (e) => (
+        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-md w-fit ${methodStyle[e.method]}`}>
+          {e.method}
+        </span>
+      ),
+    },
+    { id: "summary", header: "Summary", cell: (e) => <span className="text-ink truncate">{e.summary}</span> },
+    { id: "time", header: "Time", width: "11rem", cell: (e) => <span dir="ltr" className="text-xs text-ink-tertiary tabular-nums">{e.time}</span> },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Dashboard" />
+      <SettingsContent.Body>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
+          <StatsCard label="Entities" value={entities.length} accent="blue" />
+          <StatsCard label="Connections" value={connectionTotal} accent="green" />
+          <StatsCard label="Users" value={seedUsers.length} />
+          <StatsCard label="Languages" value={seedLanguages.length} accent="amber" />
+        </div>
+        <h3 className="text-sm font-semibold text-ink mb-3">Recent activity</h3>
+        <Table columns={columns} data={seedActivityLog.slice(0, 5)} getRowId={(e) => e.id} />
+      </SettingsContent.Body>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/ExtractorEditor.tsx
+++ b/app/src/components/settings/pages/ExtractorEditor.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field, TextInput } from "../Field";
+import { Select } from "../../shared/Select";
+import { StatusPill } from "../StatusPill";
+import { seedTemplates, type SettingsExtractor } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+const TEMPLATE_OPTIONS = seedTemplates.map((t) => ({ value: t.name, label: t.name }));
+
+/** Extractor detail/editor — opened from the Metadata Extraction list. Picks a
+ *  template + property to train a value extractor on (list → detail). */
+export function ExtractorEditor({
+  extractor,
+  onClose,
+}: {
+  extractor: SettingsExtractor | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = extractor === "new";
+  const base = isNew ? undefined : extractor;
+
+  const [template, setTemplate] = useState(base?.template ?? TEMPLATE_OPTIONS[0].value);
+  const [property, setProperty] = useState(base?.property ?? "");
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: isNew ? "Extractor created" : `${property || "Extractor"} saved`, type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Metadata Extraction"]} title={isNew ? "New extractor" : base!.property} />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6 max-w-lg">
+          <section className="flex flex-col gap-3">
+            <Field label="Template">
+              {/* Select is a calm popover; wrap so it sizes to the field. */}
+              <div className="w-fit">
+                <Select value={template} options={TEMPLATE_OPTIONS} onChange={setTemplate} ariaLabel="Template" />
+              </div>
+            </Field>
+            <Field label="Property" hint="The metadata property to suggest values for.">
+              <TextInput value={property} onChange={(e) => setProperty(e.target.value)} placeholder="e.g. Date filed" />
+            </Field>
+          </section>
+
+          {!isNew && (
+            <section className="pt-6 grid grid-cols-3 gap-3" style={{ borderTop: "1px solid var(--border-soft)" }}>
+              <Stat label="Status"><StatusPill status={base!.status} /></Stat>
+              <Stat label="Documents"><span className="text-sm text-ink tabular-nums">{base!.documents}</span></Stat>
+              <Stat label="Accuracy">
+                <span className="text-sm text-ink tabular-nums">{base!.accuracy === null ? "—" : `${base!.accuracy}%`}</span>
+              </Stat>
+            </section>
+          )}
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" disabled={!property} onClick={save}>
+          {isNew ? "Create extractor" : "Save"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}
+
+function Stat({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium text-ink-secondary">{label}</span>
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/settings/pages/ExtractorEditor.tsx
+++ b/app/src/components/settings/pages/ExtractorEditor.tsx
@@ -26,6 +26,9 @@ export function ExtractorEditor({
   const [template, setTemplate] = useState(base?.template ?? TEMPLATE_OPTIONS[0].value);
   const [property, setProperty] = useState(base?.property ?? "");
 
+  const dirty =
+    template !== (base?.template ?? TEMPLATE_OPTIONS[0].value) || property !== (base?.property ?? "");
+
   const save = () => {
     setToasts((p) => [
       ...p,
@@ -36,7 +39,7 @@ export function ExtractorEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Metadata Extraction"]} title={isNew ? "New extractor" : base!.property} />
+      <SettingsContent.Header path={["Metadata Extraction"]} title={isNew ? "New extractor" : base!.property} onBack={onClose} />
       <SettingsContent.Body>
         <div className="flex flex-col gap-6 max-w-lg">
           <section className="flex flex-col gap-3">
@@ -63,10 +66,10 @@ export function ExtractorEditor({
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" disabled={!property} onClick={save}>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button variant="success" size="sm" disabled={!dirty || !property} onClick={save}>
           {isNew ? "Create extractor" : "Save"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/FiltersPage.tsx
+++ b/app/src/components/settings/pages/FiltersPage.tsx
@@ -39,6 +39,8 @@ export function FiltersPage() {
   );
 
   const activeCount = rows.filter((r) => r.active).length;
+  const initialRows = seedFilterConfig.map((f) => ({ templateId: f.templateId, active: f.active, groupId: "" }));
+  const dirty = groups.length > 0 || JSON.stringify(rows) !== JSON.stringify(initialRows);
   const groupOptions = [
     { value: "", label: "No group" },
     ...groups.map((g) => ({ value: g.id, label: g.name || "Untitled group" })),
@@ -168,10 +170,10 @@ export function FiltersPage() {
         <Table columns={columns} data={rows} getRowId={(r) => r.templateId} />
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" onClick={save}>
+        <span className="text-xs text-ink-tertiary me-auto">{activeCount} filters shown</span>
+        <Button variant="success" size="sm" disabled={!dirty} onClick={save}>
           Save
         </Button>
-        <span className="text-xs text-ink-tertiary">{activeCount} filters shown</span>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/FiltersPage.tsx
+++ b/app/src/components/settings/pages/FiltersPage.tsx
@@ -1,0 +1,273 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { GripVertical, ChevronUp, ChevronDown, Folder, FolderPlus, Trash2 } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Checkbox } from "../../shared/Checkbox";
+import { Select } from "../../shared/Select";
+import { seedFilterConfig, seedTemplates } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+const entityCountById = Object.fromEntries(seedTemplates.map((t) => [t.id, t.entityCount]));
+const colorById = Object.fromEntries(seedFilterConfig.map((f) => [f.templateId, f.color]));
+const nameById = Object.fromEntries(seedFilterConfig.map((f) => [f.templateId, f.name]));
+
+interface FilterLeaf {
+  templateId: string;
+  active: boolean;
+}
+type FilterNode =
+  | ({ kind: "filter"; key: string } & FilterLeaf)
+  | { kind: "group"; key: string; name: string; children: FilterLeaf[] };
+
+const initialNodes: FilterNode[] = seedFilterConfig.map((f) => ({
+  kind: "filter",
+  key: f.templateId,
+  templateId: f.templateId,
+  active: f.active,
+}));
+
+/** Reorder helper — swap item `i` with its neighbour in direction `dir`. */
+function swap<T>(arr: T[], i: number, dir: -1 | 1): T[] {
+  const j = i + dir;
+  if (j < 0 || j >= arr.length) return arr;
+  const next = [...arr];
+  [next[i], next[j]] = [next[j], next[i]];
+  return next;
+}
+
+export function FiltersPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [nodes, setNodes] = useState<FilterNode[]>(initialNodes);
+  let groupSeq = nodes.filter((n) => n.kind === "group").length;
+
+  const groups = nodes.filter((n): n is Extract<FilterNode, { kind: "group" }> => n.kind === "group");
+  const groupOptions = [
+    { value: "", label: "No group" },
+    ...groups.map((g) => ({ value: g.key, label: g.name || "Untitled group" })),
+  ];
+
+  const activeCount =
+    nodes.reduce(
+      (sum, n) =>
+        sum + (n.kind === "filter" ? (n.active ? 1 : 0) : n.children.filter((c) => c.active).length),
+      0,
+    );
+
+  // ── mutations ──
+  const toggleTop = (key: string) =>
+    setNodes((prev) => prev.map((n) => (n.kind === "filter" && n.key === key ? { ...n, active: !n.active } : n)));
+  const toggleChild = (groupKey: string, templateId: string) =>
+    setNodes((prev) =>
+      prev.map((n) =>
+        n.kind === "group" && n.key === groupKey
+          ? { ...n, children: n.children.map((c) => (c.templateId === templateId ? { ...c, active: !c.active } : c)) }
+          : n,
+      ),
+    );
+  const moveTop = (i: number, dir: -1 | 1) => setNodes((prev) => swap(prev, i, dir));
+  const moveChild = (groupKey: string, i: number, dir: -1 | 1) =>
+    setNodes((prev) =>
+      prev.map((n) => (n.kind === "group" && n.key === groupKey ? { ...n, children: swap(n.children, i, dir) } : n)),
+    );
+
+  const addGroup = () => {
+    groupSeq += 1;
+    setNodes((prev) => [...prev, { kind: "group", key: `g-${prev.length}-${groupSeq}`, name: "New group", children: [] }]);
+  };
+  const renameGroup = (key: string, name: string) =>
+    setNodes((prev) => prev.map((n) => (n.kind === "group" && n.key === key ? { ...n, name } : n)));
+  const removeGroup = (key: string) =>
+    setNodes((prev) => {
+      const g = prev.find((n) => n.kind === "group" && n.key === key) as Extract<FilterNode, { kind: "group" }> | undefined;
+      const freed: FilterNode[] = (g?.children ?? []).map((c) => ({ kind: "filter", key: c.templateId, ...c }));
+      return [...prev.filter((n) => n.key !== key), ...freed];
+    });
+
+  /** Move a leaf (identified by templateId) to a target group ("" = top level). */
+  const moveLeaf = (templateId: string, fromGroupKey: string, toGroupKey: string) => {
+    if (fromGroupKey === toGroupKey) return;
+    setNodes((prev) => {
+      let leaf: FilterLeaf | undefined;
+      // pluck from source
+      const stripped = prev
+        .map((n) => {
+          if (n.kind === "filter" && fromGroupKey === "" && n.templateId === templateId) {
+            leaf = { templateId: n.templateId, active: n.active };
+            return null;
+          }
+          if (n.kind === "group" && n.key === fromGroupKey) {
+            const child = n.children.find((c) => c.templateId === templateId);
+            if (child) leaf = child;
+            return { ...n, children: n.children.filter((c) => c.templateId !== templateId) };
+          }
+          return n;
+        })
+        .filter(Boolean) as FilterNode[];
+      if (!leaf) return prev;
+      // place into target
+      if (toGroupKey === "") {
+        return [...stripped, { kind: "filter", key: leaf.templateId, ...leaf }];
+      }
+      return stripped.map((n) =>
+        n.kind === "group" && n.key === toGroupKey ? { ...n, children: [...n.children, leaf!] } : n,
+      );
+    });
+  };
+
+  const save = () =>
+    setToasts((p) => [...p, { id: Date.now().toString(), message: "Library filters updated", type: "success" as const }]);
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Filters" />
+      <SettingsContent.Body className="max-w-2xl">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between mb-4">
+          <p className="text-xs text-ink-tertiary min-w-0 sm:max-w-md">
+            Choose which entity types appear as filters in the library sidebar, group them, and set
+            their order — exactly how readers will see them.
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<FolderPlus size={14} />}
+            onClick={addGroup}
+            className="shrink-0 whitespace-nowrap"
+          >
+            New group
+          </Button>
+        </div>
+
+        <div
+          className="rounded-md bg-paper p-1.5 flex flex-col gap-0.5"
+          style={{ border: "1px solid var(--border-primary)" }}
+        >
+          {nodes.map((node, i) =>
+            node.kind === "filter" ? (
+              <FilterRow
+                key={node.key}
+                templateId={node.templateId}
+                active={node.active}
+                onToggle={() => toggleTop(node.key)}
+                onUp={i > 0 ? () => moveTop(i, -1) : undefined}
+                onDown={i < nodes.length - 1 ? () => moveTop(i, 1) : undefined}
+                groupValue=""
+                groupOptions={groupOptions}
+                onGroupChange={(to) => moveLeaf(node.templateId, "", to)}
+              />
+            ) : (
+              <div key={node.key} className="rounded-md bg-warm/40 p-1">
+                <div className="flex items-center gap-2 px-1.5 py-1">
+                  <Folder size={14} className="text-ink-tertiary shrink-0" />
+                  <input
+                    value={node.name}
+                    onChange={(e) => renameGroup(node.key, e.target.value)}
+                    aria-label="Group name"
+                    className="flex-1 min-w-0 bg-transparent text-sm font-semibold text-ink focus:outline-none focus:bg-paper rounded px-1 py-0.5"
+                  />
+                  <ReorderButtons
+                    onUp={i > 0 ? () => moveTop(i, -1) : undefined}
+                    onDown={i < nodes.length - 1 ? () => moveTop(i, 1) : undefined}
+                  />
+                  <button
+                    onClick={() => removeGroup(node.key)}
+                    aria-label={`Remove group ${node.name}`}
+                    className="p-1 rounded text-ink-tertiary hover:bg-seal-tint hover:text-seal transition-colors cursor-pointer shrink-0"
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                </div>
+                {node.children.length === 0 ? (
+                  <p className="px-2 py-2 text-[11px] text-ink-muted">
+                    Empty group — use a filter's group menu to move it here.
+                  </p>
+                ) : (
+                  <div className="ps-5 flex flex-col gap-0.5">
+                    {node.children.map((c, ci) => (
+                      <FilterRow
+                        key={c.templateId}
+                        templateId={c.templateId}
+                        active={c.active}
+                        onToggle={() => toggleChild(node.key, c.templateId)}
+                        onUp={ci > 0 ? () => moveChild(node.key, ci, -1) : undefined}
+                        onDown={ci < node.children.length - 1 ? () => moveChild(node.key, ci, 1) : undefined}
+                        groupValue={node.key}
+                        groupOptions={groupOptions}
+                        onGroupChange={(to) => moveLeaf(c.templateId, node.key, to)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            ),
+          )}
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" onClick={save}>
+          Save
+        </Button>
+        <span className="text-xs text-ink-tertiary">{activeCount} filters shown</span>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}
+
+function ReorderButtons({ onUp, onDown }: { onUp?: () => void; onDown?: () => void }) {
+  return (
+    <div className="flex items-center shrink-0">
+      <button
+        onClick={onUp}
+        disabled={!onUp}
+        aria-label="Move up"
+        className="p-0.5 rounded text-ink-tertiary hover:bg-warm hover:text-ink transition-colors disabled:opacity-30 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
+      >
+        <ChevronUp size={14} />
+      </button>
+      <button
+        onClick={onDown}
+        disabled={!onDown}
+        aria-label="Move down"
+        className="p-0.5 rounded text-ink-tertiary hover:bg-warm hover:text-ink transition-colors disabled:opacity-30 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
+      >
+        <ChevronDown size={14} />
+      </button>
+    </div>
+  );
+}
+
+function FilterRow({
+  templateId,
+  active,
+  onToggle,
+  onUp,
+  onDown,
+  groupValue,
+  groupOptions,
+  onGroupChange,
+}: {
+  templateId: string;
+  active: boolean;
+  onToggle: () => void;
+  onUp?: () => void;
+  onDown?: () => void;
+  groupValue: string;
+  groupOptions: { value: string; label: string }[];
+  onGroupChange: (to: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-md px-1.5 py-1 hover:bg-warm transition-colors">
+      <GripVertical size={14} className="text-ink-muted shrink-0 cursor-grab" />
+      <Checkbox checked={active} onChange={onToggle} ariaLabel={`Show ${nameById[templateId]} filter`} />
+      <span className="w-2.5 h-2.5 rounded-[2px] shrink-0" style={{ backgroundColor: colorById[templateId] }} />
+      <span className={`flex-1 min-w-0 truncate text-sm ${active ? "text-ink" : "text-ink-tertiary"}`}>
+        {nameById[templateId]}
+      </span>
+      <span className="text-[11px] text-ink-tertiary tabular-nums shrink-0">{entityCountById[templateId] ?? 0}</span>
+      {groupOptions.length > 1 && (
+        <Select value={groupValue} options={groupOptions} onChange={onGroupChange} ariaLabel="Move to group" align="end" />
+      )}
+      <ReorderButtons onUp={onUp} onDown={onDown} />
+    </div>
+  );
+}

--- a/app/src/components/settings/pages/FiltersPage.tsx
+++ b/app/src/components/settings/pages/FiltersPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { useSetAtom } from "jotai";
-import { GripVertical, ChevronUp, ChevronDown, Folder, FolderPlus, Trash2 } from "lucide-react";
+import { GripVertical, ChevronUp, ChevronDown, FolderPlus, Trash2 } from "lucide-react";
 import { SettingsContent } from "../SettingsContent";
 import { Button } from "../Button";
+import { Table, type Column } from "../Table";
 import { Checkbox } from "../../shared/Checkbox";
 import { Select } from "../../shared/Select";
 import { seedFilterConfig, seedTemplates } from "../../../data/settings";
@@ -12,22 +13,16 @@ const entityCountById = Object.fromEntries(seedTemplates.map((t) => [t.id, t.ent
 const colorById = Object.fromEntries(seedFilterConfig.map((f) => [f.templateId, f.color]));
 const nameById = Object.fromEntries(seedFilterConfig.map((f) => [f.templateId, f.name]));
 
-interface FilterLeaf {
+interface FilterGroup {
+  id: string;
+  name: string;
+}
+interface FilterRow {
   templateId: string;
   active: boolean;
+  groupId: string; // "" = ungrouped
 }
-type FilterNode =
-  | ({ kind: "filter"; key: string } & FilterLeaf)
-  | { kind: "group"; key: string; name: string; children: FilterLeaf[] };
 
-const initialNodes: FilterNode[] = seedFilterConfig.map((f) => ({
-  kind: "filter",
-  key: f.templateId,
-  templateId: f.templateId,
-  active: f.active,
-}));
-
-/** Reorder helper — swap item `i` with its neighbour in direction `dir`. */
 function swap<T>(arr: T[], i: number, dir: -1 | 1): T[] {
   const j = i + dir;
   if (j < 0 || j >= arr.length) return arr;
@@ -38,90 +33,100 @@ function swap<T>(arr: T[], i: number, dir: -1 | 1): T[] {
 
 export function FiltersPage() {
   const setToasts = useSetAtom(toastsAtom);
-  const [nodes, setNodes] = useState<FilterNode[]>(initialNodes);
-  let groupSeq = nodes.filter((n) => n.kind === "group").length;
+  const [groups, setGroups] = useState<FilterGroup[]>([]);
+  const [rows, setRows] = useState<FilterRow[]>(
+    seedFilterConfig.map((f) => ({ templateId: f.templateId, active: f.active, groupId: "" })),
+  );
 
-  const groups = nodes.filter((n): n is Extract<FilterNode, { kind: "group" }> => n.kind === "group");
+  const activeCount = rows.filter((r) => r.active).length;
   const groupOptions = [
     { value: "", label: "No group" },
-    ...groups.map((g) => ({ value: g.key, label: g.name || "Untitled group" })),
+    ...groups.map((g) => ({ value: g.id, label: g.name || "Untitled group" })),
   ];
 
-  const activeCount =
-    nodes.reduce(
-      (sum, n) =>
-        sum + (n.kind === "filter" ? (n.active ? 1 : 0) : n.children.filter((c) => c.active).length),
-      0,
-    );
+  const toggle = (templateId: string) =>
+    setRows((prev) => prev.map((r) => (r.templateId === templateId ? { ...r, active: !r.active } : r)));
+  const setGroup = (templateId: string, groupId: string) =>
+    setRows((prev) => prev.map((r) => (r.templateId === templateId ? { ...r, groupId } : r)));
+  const move = (i: number, dir: -1 | 1) => setRows((prev) => swap(prev, i, dir));
 
-  // ── mutations ──
-  const toggleTop = (key: string) =>
-    setNodes((prev) => prev.map((n) => (n.kind === "filter" && n.key === key ? { ...n, active: !n.active } : n)));
-  const toggleChild = (groupKey: string, templateId: string) =>
-    setNodes((prev) =>
-      prev.map((n) =>
-        n.kind === "group" && n.key === groupKey
-          ? { ...n, children: n.children.map((c) => (c.templateId === templateId ? { ...c, active: !c.active } : c)) }
-          : n,
-      ),
-    );
-  const moveTop = (i: number, dir: -1 | 1) => setNodes((prev) => swap(prev, i, dir));
-  const moveChild = (groupKey: string, i: number, dir: -1 | 1) =>
-    setNodes((prev) =>
-      prev.map((n) => (n.kind === "group" && n.key === groupKey ? { ...n, children: swap(n.children, i, dir) } : n)),
-    );
-
-  const addGroup = () => {
-    groupSeq += 1;
-    setNodes((prev) => [...prev, { kind: "group", key: `g-${prev.length}-${groupSeq}`, name: "New group", children: [] }]);
-  };
-  const renameGroup = (key: string, name: string) =>
-    setNodes((prev) => prev.map((n) => (n.kind === "group" && n.key === key ? { ...n, name } : n)));
-  const removeGroup = (key: string) =>
-    setNodes((prev) => {
-      const g = prev.find((n) => n.kind === "group" && n.key === key) as Extract<FilterNode, { kind: "group" }> | undefined;
-      const freed: FilterNode[] = (g?.children ?? []).map((c) => ({ kind: "filter", key: c.templateId, ...c }));
-      return [...prev.filter((n) => n.key !== key), ...freed];
-    });
-
-  /** Move a leaf (identified by templateId) to a target group ("" = top level). */
-  const moveLeaf = (templateId: string, fromGroupKey: string, toGroupKey: string) => {
-    if (fromGroupKey === toGroupKey) return;
-    setNodes((prev) => {
-      let leaf: FilterLeaf | undefined;
-      // pluck from source
-      const stripped = prev
-        .map((n) => {
-          if (n.kind === "filter" && fromGroupKey === "" && n.templateId === templateId) {
-            leaf = { templateId: n.templateId, active: n.active };
-            return null;
-          }
-          if (n.kind === "group" && n.key === fromGroupKey) {
-            const child = n.children.find((c) => c.templateId === templateId);
-            if (child) leaf = child;
-            return { ...n, children: n.children.filter((c) => c.templateId !== templateId) };
-          }
-          return n;
-        })
-        .filter(Boolean) as FilterNode[];
-      if (!leaf) return prev;
-      // place into target
-      if (toGroupKey === "") {
-        return [...stripped, { kind: "filter", key: leaf.templateId, ...leaf }];
-      }
-      return stripped.map((n) =>
-        n.kind === "group" && n.key === toGroupKey ? { ...n, children: [...n.children, leaf!] } : n,
-      );
-    });
+  const addGroup = () =>
+    setGroups((prev) => [...prev, { id: `g-${prev.length}-${rows.length}`, name: `Group ${prev.length + 1}` }]);
+  const renameGroup = (id: string, name: string) =>
+    setGroups((prev) => prev.map((g) => (g.id === id ? { ...g, name } : g)));
+  const removeGroup = (id: string) => {
+    setGroups((prev) => prev.filter((g) => g.id !== id));
+    setRows((prev) => prev.map((r) => (r.groupId === id ? { ...r, groupId: "" } : r)));
   };
 
   const save = () =>
     setToasts((p) => [...p, { id: Date.now().toString(), message: "Library filters updated", type: "success" as const }]);
 
+  const columns: Column<FilterRow>[] = [
+    {
+      id: "filter",
+      header: "Filter",
+      cell: (r, i) => (
+        <div className="flex items-center gap-2 w-full min-w-0">
+          <GripVertical size={14} className="text-ink-muted shrink-0 cursor-grab" />
+          <Checkbox checked={r.active} onChange={() => toggle(r.templateId)} ariaLabel={`Show ${nameById[r.templateId]}`} />
+          <span className="w-2.5 h-2.5 rounded-[2px] shrink-0" style={{ backgroundColor: colorById[r.templateId] }} />
+          <span className={`truncate text-sm ${r.active ? "text-ink" : "text-ink-tertiary"}`}>
+            {nameById[r.templateId]}
+          </span>
+          <span className="sr-only">{`row ${i + 1}`}</span>
+        </div>
+      ),
+    },
+    {
+      id: "entities",
+      header: "Entities",
+      width: "7rem",
+      cell: (r) => <span className="text-xs text-ink-tertiary tabular-nums">{entityCountById[r.templateId] ?? 0}</span>,
+    },
+    {
+      id: "group",
+      header: "Group",
+      width: "11rem",
+      cell: (r) =>
+        groupOptions.length > 1 ? (
+          <Select value={r.groupId} options={groupOptions} onChange={(g) => setGroup(r.templateId, g)} ariaLabel="Move to group" />
+        ) : (
+          <span className="text-xs text-ink-muted">—</span>
+        ),
+    },
+    {
+      id: "order",
+      header: "",
+      width: "5rem",
+      align: "right",
+      cell: (r, i) => (
+        <div className="flex items-center justify-end">
+          <button
+            onClick={() => move(i, -1)}
+            disabled={i === 0}
+            aria-label="Move up"
+            className="p-0.5 rounded text-ink-tertiary hover:bg-warm hover:text-ink transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
+          >
+            <ChevronUp size={14} />
+          </button>
+          <button
+            onClick={() => move(i, 1)}
+            disabled={i === rows.length - 1}
+            aria-label="Move down"
+            className="p-0.5 rounded text-ink-tertiary hover:bg-warm hover:text-ink transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
+          >
+            <ChevronDown size={14} />
+          </button>
+        </div>
+      ),
+    },
+  ];
+
   return (
     <SettingsContent>
       <SettingsContent.Header title="Filters" />
-      <SettingsContent.Body className="max-w-2xl">
+      <SettingsContent.Body>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between mb-4">
           <p className="text-xs text-ink-tertiary min-w-0 sm:max-w-md">
             Choose which entity types appear as filters in the library sidebar, group them, and set
@@ -138,70 +143,29 @@ export function FiltersPage() {
           </Button>
         </div>
 
-        <div
-          className="rounded-md bg-paper p-1.5 flex flex-col gap-0.5"
-          style={{ border: "1px solid var(--border-primary)" }}
-        >
-          {nodes.map((node, i) =>
-            node.kind === "filter" ? (
-              <FilterRow
-                key={node.key}
-                templateId={node.templateId}
-                active={node.active}
-                onToggle={() => toggleTop(node.key)}
-                onUp={i > 0 ? () => moveTop(i, -1) : undefined}
-                onDown={i < nodes.length - 1 ? () => moveTop(i, 1) : undefined}
-                groupValue=""
-                groupOptions={groupOptions}
-                onGroupChange={(to) => moveLeaf(node.templateId, "", to)}
-              />
-            ) : (
-              <div key={node.key} className="rounded-md bg-warm/40 p-1">
-                <div className="flex items-center gap-2 px-1.5 py-1">
-                  <Folder size={14} className="text-ink-tertiary shrink-0" />
-                  <input
-                    value={node.name}
-                    onChange={(e) => renameGroup(node.key, e.target.value)}
-                    aria-label="Group name"
-                    className="flex-1 min-w-0 bg-transparent text-sm font-semibold text-ink focus:outline-none focus:bg-paper rounded px-1 py-0.5"
-                  />
-                  <ReorderButtons
-                    onUp={i > 0 ? () => moveTop(i, -1) : undefined}
-                    onDown={i < nodes.length - 1 ? () => moveTop(i, 1) : undefined}
-                  />
-                  <button
-                    onClick={() => removeGroup(node.key)}
-                    aria-label={`Remove group ${node.name}`}
-                    className="p-1 rounded text-ink-tertiary hover:bg-seal-tint hover:text-seal transition-colors cursor-pointer shrink-0"
-                  >
-                    <Trash2 size={13} />
-                  </button>
-                </div>
-                {node.children.length === 0 ? (
-                  <p className="px-2 py-2 text-[11px] text-ink-muted">
-                    Empty group — use a filter's group menu to move it here.
-                  </p>
-                ) : (
-                  <div className="ps-5 flex flex-col gap-0.5">
-                    {node.children.map((c, ci) => (
-                      <FilterRow
-                        key={c.templateId}
-                        templateId={c.templateId}
-                        active={c.active}
-                        onToggle={() => toggleChild(node.key, c.templateId)}
-                        onUp={ci > 0 ? () => moveChild(node.key, ci, -1) : undefined}
-                        onDown={ci < node.children.length - 1 ? () => moveChild(node.key, ci, 1) : undefined}
-                        groupValue={node.key}
-                        groupOptions={groupOptions}
-                        onGroupChange={(to) => moveLeaf(c.templateId, node.key, to)}
-                      />
-                    ))}
-                  </div>
-                )}
+        {groups.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-3">
+            {groups.map((g) => (
+              <div key={g.id} className="flex items-center gap-1 rounded-md bg-warm px-2 py-1">
+                <input
+                  value={g.name}
+                  onChange={(e) => renameGroup(g.id, e.target.value)}
+                  aria-label="Group name"
+                  className="bg-transparent text-xs font-medium text-ink w-28 focus:outline-none focus:bg-paper rounded px-1"
+                />
+                <button
+                  onClick={() => removeGroup(g.id)}
+                  aria-label={`Remove ${g.name}`}
+                  className="p-0.5 rounded text-ink-tertiary hover:bg-seal-tint hover:text-seal transition-colors cursor-pointer shrink-0"
+                >
+                  <Trash2 size={12} />
+                </button>
               </div>
-            ),
-          )}
-        </div>
+            ))}
+          </div>
+        )}
+
+        <Table columns={columns} data={rows} getRowId={(r) => r.templateId} />
       </SettingsContent.Body>
       <SettingsContent.Footer>
         <Button variant="primary" size="sm" onClick={save}>
@@ -210,64 +174,5 @@ export function FiltersPage() {
         <span className="text-xs text-ink-tertiary">{activeCount} filters shown</span>
       </SettingsContent.Footer>
     </SettingsContent>
-  );
-}
-
-function ReorderButtons({ onUp, onDown }: { onUp?: () => void; onDown?: () => void }) {
-  return (
-    <div className="flex items-center shrink-0">
-      <button
-        onClick={onUp}
-        disabled={!onUp}
-        aria-label="Move up"
-        className="p-0.5 rounded text-ink-tertiary hover:bg-warm hover:text-ink transition-colors disabled:opacity-30 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
-      >
-        <ChevronUp size={14} />
-      </button>
-      <button
-        onClick={onDown}
-        disabled={!onDown}
-        aria-label="Move down"
-        className="p-0.5 rounded text-ink-tertiary hover:bg-warm hover:text-ink transition-colors disabled:opacity-30 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
-      >
-        <ChevronDown size={14} />
-      </button>
-    </div>
-  );
-}
-
-function FilterRow({
-  templateId,
-  active,
-  onToggle,
-  onUp,
-  onDown,
-  groupValue,
-  groupOptions,
-  onGroupChange,
-}: {
-  templateId: string;
-  active: boolean;
-  onToggle: () => void;
-  onUp?: () => void;
-  onDown?: () => void;
-  groupValue: string;
-  groupOptions: { value: string; label: string }[];
-  onGroupChange: (to: string) => void;
-}) {
-  return (
-    <div className="flex items-center gap-2 rounded-md px-1.5 py-1 hover:bg-warm transition-colors">
-      <GripVertical size={14} className="text-ink-muted shrink-0 cursor-grab" />
-      <Checkbox checked={active} onChange={onToggle} ariaLabel={`Show ${nameById[templateId]} filter`} />
-      <span className="w-2.5 h-2.5 rounded-[2px] shrink-0" style={{ backgroundColor: colorById[templateId] }} />
-      <span className={`flex-1 min-w-0 truncate text-sm ${active ? "text-ink" : "text-ink-tertiary"}`}>
-        {nameById[templateId]}
-      </span>
-      <span className="text-[11px] text-ink-tertiary tabular-nums shrink-0">{entityCountById[templateId] ?? 0}</span>
-      {groupOptions.length > 1 && (
-        <Select value={groupValue} options={groupOptions} onChange={onGroupChange} ariaLabel="Move to group" align="end" />
-      )}
-      <ReorderButtons onUp={onUp} onDown={onDown} />
-    </div>
   );
 }

--- a/app/src/components/settings/pages/GroupEditor.tsx
+++ b/app/src/components/settings/pages/GroupEditor.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field, TextInput } from "../Field";
+import { Checkbox } from "../../shared/Checkbox";
+import { seedUsers, type SettingsGroupRecord } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+/** Group detail/editor — name + membership, opened from the Groups tab. */
+export function GroupEditor({
+  group,
+  onClose,
+}: {
+  group: SettingsGroupRecord | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = group === "new";
+  const base = isNew ? undefined : group;
+
+  const [name, setName] = useState(base?.name ?? "");
+  const [members, setMembers] = useState<string[]>(
+    isNew ? [] : seedUsers.filter((u) => u.groups.includes(base!.name)).map((u) => u.id),
+  );
+
+  const toggle = (id: string) =>
+    setMembers((prev) => (prev.includes(id) ? prev.filter((m) => m !== id) : [...prev, id]));
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: isNew ? "Group created" : `${name || "Group"} saved`, type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Users & Groups"]} title={isNew ? "New group" : base!.name} />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6">
+          <section className="max-w-sm">
+            <Field label="Group name">
+              <TextInput value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Litigation" />
+            </Field>
+          </section>
+
+          <section className="pt-6" style={{ borderTop: "1px solid var(--border-soft)" }}>
+            <h3 className="text-sm font-semibold text-ink mb-1">Members</h3>
+            <p className="text-xs text-ink-tertiary mb-3">{members.length} of {seedUsers.length} users.</p>
+            <div className="flex flex-col gap-2">
+              {seedUsers.map((u) => (
+                <label
+                  key={u.id}
+                  className="flex items-center gap-3 rounded-lg border border-border bg-paper px-3 py-2.5 cursor-pointer hover:bg-warm transition-colors"
+                >
+                  <Checkbox checked={members.includes(u.id)} onChange={() => toggle(u.id)} ariaLabel={u.username} />
+                  <span className="flex items-center justify-center w-7 h-7 rounded-md bg-vellum text-[11px] font-semibold text-ink-secondary uppercase shrink-0">
+                    {u.username.slice(0, 2)}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-medium text-ink truncate">{u.username}</span>
+                    <span className="block text-xs text-ink-tertiary truncate">{u.email}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </section>
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" disabled={!name} onClick={save}>
+          {isNew ? "Create group" : "Save"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/GroupEditor.tsx
+++ b/app/src/components/settings/pages/GroupEditor.tsx
@@ -24,6 +24,12 @@ export function GroupEditor({
     isNew ? [] : seedUsers.filter((u) => u.groups.includes(base!.name)).map((u) => u.id),
   );
 
+  const initialMembers = isNew
+    ? []
+    : seedUsers.filter((u) => u.groups.includes(base!.name)).map((u) => u.id);
+  const dirty =
+    name !== (base?.name ?? "") || JSON.stringify(members) !== JSON.stringify(initialMembers);
+
   const toggle = (id: string) =>
     setMembers((prev) => (prev.includes(id) ? prev.filter((m) => m !== id) : [...prev, id]));
 
@@ -37,7 +43,7 @@ export function GroupEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Users & Groups"]} title={isNew ? "New group" : base!.name} />
+      <SettingsContent.Header path={["Users & Groups"]} title={isNew ? "New group" : base!.name} onBack={onClose} />
       <SettingsContent.Body>
         <div className="flex flex-col gap-6">
           <section className="max-w-sm">
@@ -70,10 +76,10 @@ export function GroupEditor({
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" disabled={!name} onClick={save}>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button variant="success" size="sm" disabled={!dirty || !name} onClick={save}>
           {isNew ? "Create group" : "Save"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/LanguagesPage.tsx
+++ b/app/src/components/settings/pages/LanguagesPage.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus, RotateCcw, Trash2, Check } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { ProgressBar } from "../../shared/ProgressBar";
+import { seedLanguages, type SettingsLanguage } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+export function LanguagesPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [languages, setLanguages] = useState<SettingsLanguage[]>(seedLanguages);
+  const [confirm, setConfirm] = useState<{ kind: "reset" | "uninstall"; lang: SettingsLanguage } | null>(
+    null,
+  );
+
+  const toast = (message: string) =>
+    setToasts((prev) => [...prev, { id: Date.now().toString(), message, type: "success" as const }]);
+
+  const setDefault = (key: string) =>
+    setLanguages((prev) => prev.map((l) => ({ ...l, default: l.key === key })));
+
+  const columns: Column<SettingsLanguage>[] = [
+    {
+      id: "label",
+      header: "Language",
+      cell: (l) => (
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-ink">{l.label}</span>
+          <span className="text-ink-tertiary">{l.localizedLabel}</span>
+          {!l.ltr && (
+            <span className="text-[10px] font-semibold text-ink-tertiary bg-vellum px-1.5 py-px rounded w-fit">
+              RTL
+            </span>
+          )}
+          {l.default && (
+            <span className="text-[10px] font-semibold text-carbon bg-carbon-tint px-1.5 py-px rounded w-fit">
+              Default
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      id: "translations",
+      header: "Translations",
+      width: "13rem",
+      cell: (l) => (
+        <div className="flex items-center gap-2">
+          <div className="flex-1">
+            <ProgressBar value={l.translationsCount} color={l.translationsCount === 100 ? "green" : "blue"} />
+          </div>
+          <span className="text-xs text-ink-tertiary tabular-nums w-9 text-right">
+            {l.translationsCount}%
+          </span>
+        </div>
+      ),
+    },
+    {
+      id: "default",
+      header: "Default",
+      align: "center",
+      width: "6rem",
+      cell: (l) =>
+        l.default ? (
+          <Check size={16} className="text-success mx-auto" />
+        ) : (
+          <button
+            onClick={() => {
+              setDefault(l.key);
+              toast(`${l.label} set as default language`);
+            }}
+            className="text-xs font-medium text-carbon hover:underline cursor-pointer"
+          >
+            Set
+          </button>
+        ),
+    },
+    {
+      id: "reset",
+      header: "Reset",
+      align: "center",
+      width: "5rem",
+      cell: (l) => (
+        <button
+          onClick={() => setConfirm({ kind: "reset", lang: l })}
+          aria-label={`Reset ${l.label}`}
+          className="p-1.5 rounded-md text-ink-tertiary hover:bg-warm hover:text-ink transition-colors cursor-pointer"
+        >
+          <RotateCcw size={14} />
+        </button>
+      ),
+    },
+    {
+      id: "uninstall",
+      header: "Uninstall",
+      align: "center",
+      width: "6rem",
+      cell: (l) =>
+        l.default ? (
+          <span className="text-ink-muted">—</span>
+        ) : (
+          <button
+            onClick={() => setConfirm({ kind: "uninstall", lang: l })}
+            aria-label={`Uninstall ${l.label}`}
+            className="p-1.5 rounded-md text-ink-tertiary hover:bg-seal-tint hover:text-seal transition-colors cursor-pointer"
+          >
+            <Trash2 size={14} />
+          </button>
+        ),
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Languages" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Active languages for your collection. The default language is shown to users who haven't
+          chosen one.
+        </p>
+        <Table columns={columns} data={languages} getRowId={(l) => l.key} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Plus size={14} />}>
+          Install language
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title={confirm?.kind === "reset" ? "Reset language" : "Uninstall language"}
+        message={
+          confirm?.kind === "reset"
+            ? `Reset all translations for ${confirm?.lang.label} to their default values? This can't be undone.`
+            : `Uninstall ${confirm?.lang.label}? All its translations will be removed from the collection.`
+        }
+        confirmLabel={confirm?.kind === "reset" ? "Reset" : "Uninstall"}
+        variant="danger"
+        onConfirm={() => {
+          if (!confirm) return;
+          if (confirm.kind === "uninstall") {
+            setLanguages((prev) => prev.filter((l) => l.key !== confirm.lang.key));
+            toast(`${confirm.lang.label} uninstalled`);
+          } else {
+            toast(`${confirm.lang.label} translations reset`);
+          }
+          setConfirm(null);
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/MenuLinkEditor.tsx
+++ b/app/src/components/settings/pages/MenuLinkEditor.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field, TextInput } from "../Field";
+import { RadioGroup } from "../../shared/RadioGroup";
+import { type SettingsMenuLink } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+/** Menu-link detail/editor — opened from the Menu list (list → detail). A link
+ *  points at a URL; a group nests links under a dropdown (no URL of its own). */
+export function MenuLinkEditor({
+  link,
+  onClose,
+}: {
+  link: SettingsMenuLink | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = link === "new";
+  const base = isNew ? undefined : link;
+
+  const [type, setType] = useState<"link" | "group">(base?.type ?? "link");
+  const [title, setTitle] = useState(base?.title ?? "");
+  const [url, setUrl] = useState(base?.url ?? "");
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: isNew ? "Menu item added" : `${title || "Item"} saved`, type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Menu"]} title={isNew ? "New menu item" : base!.title} />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6 max-w-lg">
+          <RadioGroup
+            name="menu-type"
+            ariaLabel="Item type"
+            inline
+            value={type}
+            onChange={(v) => setType(v as "link" | "group")}
+            options={[
+              { id: "link", label: "Link", hint: "Points at a URL" },
+              { id: "group", label: "Group", hint: "Nests links in a dropdown" },
+            ]}
+          />
+          <Field label="Label">
+            <TextInput value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. About" />
+          </Field>
+          {type === "link" && (
+            <Field label="URL" hint="An internal path (/page/about) or a full URL.">
+              <TextInput value={url} onChange={(e) => setUrl(e.target.value)} placeholder="/page/about" />
+            </Field>
+          )}
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" disabled={!title} onClick={save}>
+          {isNew ? "Add item" : "Save"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/MenuLinkEditor.tsx
+++ b/app/src/components/settings/pages/MenuLinkEditor.tsx
@@ -24,6 +24,9 @@ export function MenuLinkEditor({
   const [title, setTitle] = useState(base?.title ?? "");
   const [url, setUrl] = useState(base?.url ?? "");
 
+  const dirty =
+    type !== (base?.type ?? "link") || title !== (base?.title ?? "") || url !== (base?.url ?? "");
+
   const save = () => {
     setToasts((p) => [
       ...p,
@@ -34,7 +37,7 @@ export function MenuLinkEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Menu"]} title={isNew ? "New menu item" : base!.title} />
+      <SettingsContent.Header path={["Menu"]} title={isNew ? "New menu item" : base!.title} onBack={onClose} />
       <SettingsContent.Body>
         <div className="flex flex-col gap-6 max-w-lg">
           <RadioGroup
@@ -59,10 +62,10 @@ export function MenuLinkEditor({
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" disabled={!title} onClick={save}>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button variant="success" size="sm" disabled={!dirty || !title} onClick={save}>
           {isNew ? "Add item" : "Save"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/MenuPage.tsx
+++ b/app/src/components/settings/pages/MenuPage.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus, Link2, Folder } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { MenuLinkEditor } from "./MenuLinkEditor";
+import { seedMenuLinks, type SettingsMenuLink } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+export function MenuPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [links, setLinks] = useState<SettingsMenuLink[]>(seedMenuLinks);
+  const [confirm, setConfirm] = useState<SettingsMenuLink | null>(null);
+  const [editing, setEditing] = useState<SettingsMenuLink | "new" | null>(null);
+
+  if (editing) return <MenuLinkEditor link={editing} onClose={() => setEditing(null)} />;
+
+  const columns: Column<SettingsMenuLink>[] = [
+    {
+      id: "title",
+      header: "Label",
+      cell: (m) => (
+        <div className="flex items-center gap-2">
+          {m.type === "group" ? (
+            <Folder size={14} className="text-ink-muted shrink-0" />
+          ) : (
+            <Link2 size={14} className="text-ink-muted shrink-0" />
+          )}
+          <span className="font-medium text-ink truncate">{m.title}</span>
+        </div>
+      ),
+    },
+    {
+      id: "url",
+      header: "URL",
+      cell: (m) =>
+        m.url ? (
+          <span dir="ltr" className="text-xs text-ink-tertiary truncate">{m.url}</span>
+        ) : (
+          <span className="text-[11px] font-semibold text-ink-secondary bg-warm px-2 py-0.5 rounded-md w-fit">Group</span>
+        ),
+    },
+    {
+      id: "actions",
+      header: "",
+      width: "6rem",
+      align: "right",
+      cell: (m) => <RowActions label={m.title} onEdit={() => setEditing(m)} onDelete={() => setConfirm(m)} />,
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Menu" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Links shown in the top navigation. Groups nest links into a dropdown.
+        </p>
+        <Table columns={columns} data={links} getRowId={(m) => m.id} onRowClick={(m) => setEditing(m)} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Plus size={14} />} onClick={() => setEditing("new")}>
+          Add link
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title="Delete menu link"
+        message={`Remove “${confirm?.title}” from the navigation menu?`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirm) {
+            setLinks((prev) => prev.filter((m) => m.id !== confirm.id));
+            setToasts((p) => [...p, { id: Date.now().toString(), message: `${confirm.title} removed`, type: "success" as const }]);
+          }
+          setConfirm(null);
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/MetadataExtractionPage.tsx
+++ b/app/src/components/settings/pages/MetadataExtractionPage.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { StatusPill } from "../StatusPill";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { ExtractorEditor } from "./ExtractorEditor";
+import { seedExtractors, type SettingsExtractor } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+export function MetadataExtractionPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [extractors, setExtractors] = useState<SettingsExtractor[]>(seedExtractors);
+  const [confirm, setConfirm] = useState<SettingsExtractor | null>(null);
+  const [editing, setEditing] = useState<SettingsExtractor | "new" | null>(null);
+
+  if (editing) return <ExtractorEditor extractor={editing} onClose={() => setEditing(null)} />;
+
+  const columns: Column<SettingsExtractor>[] = [
+    {
+      id: "property",
+      header: "Property",
+      cell: (x) => (
+        <div className="min-w-0">
+          <p className="font-medium text-ink truncate">{x.property}</p>
+          <p className="text-xs text-ink-tertiary truncate">{x.template}</p>
+        </div>
+      ),
+    },
+    { id: "status", header: "Status", width: "8rem", cell: (x) => <StatusPill status={x.status} /> },
+    { id: "documents", header: "Documents", width: "8rem", cell: (x) => <span className="text-ink-secondary tabular-nums">{x.documents}</span> },
+    {
+      id: "accuracy",
+      header: "Accuracy",
+      width: "7rem",
+      cell: (x) =>
+        x.accuracy === null ? (
+          <span className="text-ink-muted">—</span>
+        ) : (
+          <span className="text-ink-secondary tabular-nums">{x.accuracy}%</span>
+        ),
+    },
+    { id: "actions", header: "", width: "6rem", align: "right", cell: (x) => <RowActions label={x.property} onEdit={() => setEditing(x)} onDelete={() => setConfirm(x)} /> },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Metadata Extraction" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Train extractors to suggest property values from document text automatically.
+        </p>
+        <Table columns={columns} data={extractors} getRowId={(x) => x.id} onRowClick={(x) => setEditing(x)} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Plus size={14} />} onClick={() => setEditing("new")}>
+          Create extractor
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title="Delete extractor"
+        message={`Delete the extractor for “${confirm?.property}”? Its training data will be discarded.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirm) {
+            setExtractors((prev) => prev.filter((x) => x.id !== confirm.id));
+            setToasts((p) => [...p, { id: Date.now().toString(), message: `Extractor deleted`, type: "success" as const }]);
+          }
+          setConfirm(null);
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/PageEditor.tsx
+++ b/app/src/components/settings/pages/PageEditor.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field, TextInput } from "../Field";
+import { Checkbox } from "../../shared/Checkbox";
+import { type SettingsPage } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+const SAMPLE_BODY = `# About this collection
+
+This archive documents cases before the Inter-American human rights system.
+
+Write the page content in Markdown.`;
+
+/** Page detail/editor — title, slug, publish state, and Markdown content.
+ *  Opened from the Pages list (list → detail). */
+export function PageEditor({
+  page,
+  onClose,
+}: {
+  page: SettingsPage | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = page === "new";
+  const base = isNew ? undefined : page;
+
+  const [title, setTitle] = useState(base?.title ?? "");
+  const [slug, setSlug] = useState(base?.slug ?? "");
+  const [published, setPublished] = useState(base?.published ?? false);
+  const [body, setBody] = useState(isNew ? "" : SAMPLE_BODY);
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: isNew ? "Page created" : `${title || "Page"} saved`, type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Pages"]} title={isNew ? "New page" : base!.title} />
+      <SettingsContent.Body className="flex flex-col min-h-0">
+        <section className="grid sm:grid-cols-2 gap-3 mb-4">
+          <Field label="Title">
+            <TextInput value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. Methodology" />
+          </Field>
+          <Field label="URL slug" hint={`/page/${slug || "…"}`}>
+            <TextInput value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="methodology" />
+          </Field>
+        </section>
+
+        <label className="flex items-center gap-2.5 mb-4 cursor-pointer w-fit">
+          <Checkbox checked={published} onChange={(e) => setPublished(e.target.checked)} ariaLabel="Published" />
+          <span className="text-sm text-ink">Published</span>
+          <span className="text-xs text-ink-tertiary">— visible to readers</span>
+        </label>
+
+        <Field label="Content">
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            spellCheck={false}
+            placeholder="Write the page content in Markdown…"
+            className="w-full min-h-[16rem] p-4 text-sm font-mono text-ink bg-warm border border-border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-carbon/20"
+          />
+        </Field>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" disabled={!title} onClick={save}>
+          {isNew ? "Create page" : "Save"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/PageEditor.tsx
+++ b/app/src/components/settings/pages/PageEditor.tsx
@@ -31,6 +31,12 @@ export function PageEditor({
   const [published, setPublished] = useState(base?.published ?? false);
   const [body, setBody] = useState(isNew ? "" : SAMPLE_BODY);
 
+  const dirty =
+    title !== (base?.title ?? "") ||
+    slug !== (base?.slug ?? "") ||
+    published !== (base?.published ?? false) ||
+    body !== (isNew ? "" : SAMPLE_BODY);
+
   const save = () => {
     setToasts((p) => [
       ...p,
@@ -41,7 +47,7 @@ export function PageEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Pages"]} title={isNew ? "New page" : base!.title} />
+      <SettingsContent.Header path={["Pages"]} title={isNew ? "New page" : base!.title} onBack={onClose} />
       <SettingsContent.Body className="flex flex-col min-h-0">
         <section className="grid sm:grid-cols-2 gap-3 mb-4">
           <Field label="Title">
@@ -69,10 +75,10 @@ export function PageEditor({
         </Field>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" disabled={!title} onClick={save}>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button variant="success" size="sm" disabled={!dirty || !title} onClick={save}>
           {isNew ? "Create page" : "Save"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/PagesPage.tsx
+++ b/app/src/components/settings/pages/PagesPage.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { PageEditor } from "./PageEditor";
+import { seedPages, type SettingsPage } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+export function PagesPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [pages, setPages] = useState<SettingsPage[]>(seedPages);
+  const [confirm, setConfirm] = useState<SettingsPage | null>(null);
+  const [editing, setEditing] = useState<SettingsPage | "new" | null>(null);
+
+  if (editing) return <PageEditor page={editing} onClose={() => setEditing(null)} />;
+
+  const columns: Column<SettingsPage>[] = [
+    {
+      id: "title",
+      header: "Title",
+      cell: (p) => <span className="font-medium text-ink truncate">{p.title}</span>,
+    },
+    {
+      id: "slug",
+      header: "URL",
+      cell: (p) => <span dir="ltr" className="text-xs text-ink-tertiary truncate">/page/{p.slug}</span>,
+    },
+    {
+      id: "published",
+      header: "Status",
+      width: "8rem",
+      cell: (p) =>
+        p.published ? (
+          <span className="text-[11px] font-semibold text-success bg-success-light px-2 py-0.5 rounded-md w-fit">
+            Published
+          </span>
+        ) : (
+          <span className="text-[11px] font-semibold text-ink-secondary bg-warm px-2 py-0.5 rounded-md w-fit">
+            Draft
+          </span>
+        ),
+    },
+    {
+      id: "actions",
+      header: "",
+      width: "6rem",
+      align: "right",
+      cell: (p) => <RowActions label={p.title} onEdit={() => setEditing(p)} onDelete={() => setConfirm(p)} />,
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Pages" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Custom pages for your collection — about pages, methodology, landing content.
+        </p>
+        <Table columns={columns} data={pages} getRowId={(p) => p.id} onRowClick={(p) => setEditing(p)} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Plus size={14} />} onClick={() => setEditing("new")}>
+          Add page
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title="Delete page"
+        message={`Delete “${confirm?.title}”? Any menu links pointing to it will break.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirm) {
+            setPages((prev) => prev.filter((p) => p.id !== confirm.id));
+            setToasts((p) => [...p, { id: Date.now().toString(), message: `${confirm.title} deleted`, type: "success" as const }]);
+          }
+          setConfirm(null);
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/ParagraphExtractionPage.tsx
+++ b/app/src/components/settings/pages/ParagraphExtractionPage.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { StatusPill } from "../StatusPill";
+import { ParagraphJobEditor } from "./ParagraphJobEditor";
+import { seedParagraphJobs, type SettingsParagraphJob } from "../../../data/settings";
+
+export function ParagraphExtractionPage() {
+  const [editing, setEditing] = useState<SettingsParagraphJob | "new" | null>(null);
+
+  if (editing) return <ParagraphJobEditor job={editing} onClose={() => setEditing(null)} />;
+
+  const columns: Column<SettingsParagraphJob>[] = [
+    { id: "template", header: "Template", cell: (j) => <span className="font-medium text-ink truncate">{j.template}</span> },
+    { id: "status", header: "Status", width: "8rem", cell: (j) => <StatusPill status={j.status} /> },
+    {
+      id: "paragraphs",
+      header: "Paragraphs",
+      width: "9rem",
+      cell: (j) => <span className="text-ink-secondary tabular-nums">{j.paragraphs.toLocaleString()}</span>,
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Paragraph Extraction" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Split documents into paragraph-level records for fine-grained search and analysis.
+        </p>
+        <Table columns={columns} data={seedParagraphJobs} getRowId={(j) => j.id} onRowClick={(j) => setEditing(j)} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Plus size={14} />} onClick={() => setEditing("new")}>
+          New extraction
+        </Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/ParagraphJobEditor.tsx
+++ b/app/src/components/settings/pages/ParagraphJobEditor.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field } from "../Field";
+import { Select } from "../../shared/Select";
+import { StatusPill } from "../StatusPill";
+import { seedTemplates, type SettingsParagraphJob } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+const TEMPLATE_OPTIONS = seedTemplates.map((t) => ({ value: t.name, label: t.name }));
+
+/** Paragraph-extraction detail — opened from the list. "new" configures a fresh
+ *  extraction (pick a template, start it); an existing job shows its progress. */
+export function ParagraphJobEditor({
+  job,
+  onClose,
+}: {
+  job: SettingsParagraphJob | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = job === "new";
+  const base = isNew ? undefined : job;
+
+  const [template, setTemplate] = useState(base?.template ?? TEMPLATE_OPTIONS[0].value);
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: isNew ? "Extraction started" : "Extraction re-run queued", type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Paragraph Extraction"]} title={isNew ? "New extraction" : base!.template} />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6 max-w-lg">
+          <p className="text-xs text-ink-tertiary">
+            Split every document of a template into paragraph-level records for fine-grained search.
+          </p>
+          <Field label="Template">
+            {isNew ? (
+              <div className="w-fit">
+                <Select value={template} options={TEMPLATE_OPTIONS} onChange={setTemplate} ariaLabel="Template" />
+              </div>
+            ) : (
+              <span className="text-sm text-ink">{base!.template}</span>
+            )}
+          </Field>
+
+          {!isNew && (
+            <section className="pt-6 grid grid-cols-2 gap-3" style={{ borderTop: "1px solid var(--border-soft)" }}>
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-ink-secondary">Status</span>
+                <StatusPill status={base!.status} />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-ink-secondary">Paragraphs</span>
+                <span className="text-sm text-ink tabular-nums">{base!.paragraphs.toLocaleString()}</span>
+              </div>
+            </section>
+          )}
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" onClick={save}>
+          {isNew ? "Start extraction" : "Re-run"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/ParagraphJobEditor.tsx
+++ b/app/src/components/settings/pages/ParagraphJobEditor.tsx
@@ -35,7 +35,7 @@ export function ParagraphJobEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Paragraph Extraction"]} title={isNew ? "New extraction" : base!.template} />
+      <SettingsContent.Header path={["Paragraph Extraction"]} title={isNew ? "New extraction" : base!.template} onBack={onClose} />
       <SettingsContent.Body>
         <div className="flex flex-col gap-6 max-w-lg">
           <p className="text-xs text-ink-tertiary">
@@ -66,10 +66,10 @@ export function ParagraphJobEditor({
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
         <Button variant="primary" size="sm" onClick={save}>
           {isNew ? "Start extraction" : "Re-run"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/PlaceholderPage.tsx
+++ b/app/src/components/settings/pages/PlaceholderPage.tsx
@@ -1,0 +1,29 @@
+import { SettingsContent } from "../SettingsContent";
+import { settingsItemsById } from "../../../atoms/settings";
+
+/** Stub body for settings sections not yet cloned — keeps the whole IA
+ *  navigable while individual pages are built out. */
+export function PlaceholderPage({ section }: { section: string }) {
+  const item = settingsItemsById[section];
+  const Icon = item?.icon;
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title={item?.label ?? "Settings"} />
+      <SettingsContent.Body>
+        <div className="h-full flex flex-col items-center justify-center text-center gap-3 py-16">
+          {Icon && (
+            <span className="flex items-center justify-center w-12 h-12 rounded-lg bg-vellum">
+              <Icon size={22} className="text-ink-tertiary" />
+            </span>
+          )}
+          <div>
+            <p className="text-sm font-semibold text-ink">{item?.label}</p>
+            <p className="text-xs text-ink-tertiary mt-1 max-w-xs">
+              This settings page is part of the cloning roadmap and hasn't been built yet.
+            </p>
+          </div>
+        </div>
+      </SettingsContent.Body>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/PreservePage.tsx
+++ b/app/src/components/settings/pages/PreservePage.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { PreserveTokenEditor } from "./PreserveTokenEditor";
+import { seedPreserveTokens, type SettingsPreserveToken } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+export function PreservePage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [tokens, setTokens] = useState<SettingsPreserveToken[]>(seedPreserveTokens);
+  const [confirm, setConfirm] = useState<SettingsPreserveToken | null>(null);
+  const [editing, setEditing] = useState<SettingsPreserveToken | "new" | null>(null);
+
+  if (editing) return <PreserveTokenEditor token={editing} onClose={() => setEditing(null)} />;
+
+  const columns: Column<SettingsPreserveToken>[] = [
+    { id: "name", header: "Source", cell: (t) => <span className="font-medium text-ink truncate">{t.name}</span> },
+    {
+      id: "token",
+      header: "Token",
+      width: "11rem",
+      cell: (t) => (
+        <span dir="ltr" className="text-xs text-ink-tertiary font-mono bg-vellum px-1.5 py-0.5 rounded w-fit">
+          {t.token}
+        </span>
+      ),
+    },
+    { id: "captured", header: "Captured", width: "7rem", cell: (t) => <span className="text-ink-secondary tabular-nums">{t.capturedCount}</span> },
+    { id: "lastRun", header: "Last run", width: "11rem", cell: (t) => <span dir="ltr" className="text-xs text-ink-tertiary tabular-nums">{t.lastRun}</span> },
+    { id: "actions", header: "", width: "6rem", align: "right", cell: (t) => <RowActions label={t.name} onEdit={() => setEditing(t)} onDelete={() => setConfirm(t)} /> },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Preserve" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Capture and archive web sources on a schedule. Each token authenticates one capture source.
+        </p>
+        <Table columns={columns} data={tokens} getRowId={(t) => t.id} onRowClick={(t) => setEditing(t)} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Plus size={14} />} onClick={() => setEditing("new")}>
+          New token
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title="Revoke token"
+        message={`Revoke the token for “${confirm?.name}”? Scheduled captures from this source will stop.`}
+        confirmLabel="Revoke"
+        variant="danger"
+        onConfirm={() => {
+          if (confirm) {
+            setTokens((prev) => prev.filter((t) => t.id !== confirm.id));
+            setToasts((p) => [...p, { id: Date.now().toString(), message: `Token revoked`, type: "success" as const }]);
+          }
+          setConfirm(null);
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/PreserveTokenEditor.tsx
+++ b/app/src/components/settings/pages/PreserveTokenEditor.tsx
@@ -24,6 +24,8 @@ export function PreserveTokenEditor({
   const [name, setName] = useState(base?.name ?? "");
   const [schedule, setSchedule] = useState("daily");
 
+  const dirty = name !== (base?.name ?? "") || schedule !== "daily";
+
   const toast = (message: string) =>
     setToasts((p) => [...p, { id: Date.now().toString(), message, type: "success" as const }]);
 
@@ -34,7 +36,7 @@ export function PreserveTokenEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Preserve"]} title={isNew ? "New capture source" : base!.name} />
+      <SettingsContent.Header path={["Preserve"]} title={isNew ? "New capture source" : base!.name} onBack={onClose} />
       <SettingsContent.Body>
         <div className="flex flex-col gap-6 max-w-lg">
           <Field label="Source name">
@@ -84,10 +86,10 @@ export function PreserveTokenEditor({
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" disabled={!name} onClick={save}>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button variant="success" size="sm" disabled={!dirty || !name} onClick={save}>
           {isNew ? "Add source" : "Save"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/PreserveTokenEditor.tsx
+++ b/app/src/components/settings/pages/PreserveTokenEditor.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Copy } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field, TextInput } from "../Field";
+import { RadioGroup } from "../../shared/RadioGroup";
+import { type SettingsPreserveToken } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+/** Preserve-token detail/editor — opened from the Preserve list. A token
+ *  authenticates one capture source on a schedule (list → detail). */
+export function PreserveTokenEditor({
+  token,
+  onClose,
+}: {
+  token: SettingsPreserveToken | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = token === "new";
+  const base = isNew ? undefined : token;
+
+  const [name, setName] = useState(base?.name ?? "");
+  const [schedule, setSchedule] = useState("daily");
+
+  const toast = (message: string) =>
+    setToasts((p) => [...p, { id: Date.now().toString(), message, type: "success" as const }]);
+
+  const save = () => {
+    toast(isNew ? "Capture source added" : `${name || "Source"} saved`);
+    onClose();
+  };
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Preserve"]} title={isNew ? "New capture source" : base!.name} />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6 max-w-lg">
+          <Field label="Source name">
+            <TextInput value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Court press releases" />
+          </Field>
+
+          <div>
+            <h3 className="text-sm font-semibold text-ink mb-1">Capture schedule</h3>
+            <p className="text-xs text-ink-tertiary mb-3">How often Preserve re-captures this source.</p>
+            <RadioGroup
+              name="preserve-schedule"
+              ariaLabel="Capture schedule"
+              inline
+              value={schedule}
+              onChange={setSchedule}
+              options={[
+                { id: "hourly", label: "Hourly" },
+                { id: "daily", label: "Daily" },
+                { id: "weekly", label: "Weekly" },
+              ]}
+            />
+          </div>
+
+          {!isNew && (
+            <section className="pt-6 flex flex-col gap-3" style={{ borderTop: "1px solid var(--border-soft)" }}>
+              <Field label="Token">
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 min-w-0 truncate text-xs font-mono text-ink-secondary bg-vellum px-3 py-2 rounded-md" dir="ltr">
+                    {base!.token}
+                  </code>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    icon={<Copy size={13} />}
+                    onClick={() => toast("Token copied")}
+                  >
+                    Copy
+                  </Button>
+                </div>
+              </Field>
+              <p className="text-xs text-ink-tertiary">
+                <span className="font-semibold text-ink-secondary tabular-nums">{base!.capturedCount}</span> captures ·
+                last run <span dir="ltr" className="tabular-nums">{base!.lastRun}</span>
+              </p>
+            </section>
+          )}
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" disabled={!name} onClick={save}>
+          {isNew ? "Add source" : "Save"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/RelationTypeEditor.tsx
+++ b/app/src/components/settings/pages/RelationTypeEditor.tsx
@@ -19,6 +19,7 @@ export function RelationTypeEditor({
   const base = isNew ? undefined : relationType;
 
   const [name, setName] = useState(base?.name ?? "");
+  const dirty = name !== (base?.name ?? "");
 
   const save = () => {
     setToasts((p) => [
@@ -30,7 +31,7 @@ export function RelationTypeEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Relationship types"]} title={isNew ? "New relationship type" : base!.name} />
+      <SettingsContent.Header path={["Relationship types"]} title={isNew ? "New relationship type" : base!.name} onBack={onClose} />
       <SettingsContent.Body>
         <div className="flex flex-col gap-4 max-w-sm">
           <Field label="Name" hint="The label shown when connecting two entities.">
@@ -44,10 +45,10 @@ export function RelationTypeEditor({
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" disabled={!name} onClick={save}>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button variant="success" size="sm" disabled={!dirty || !name} onClick={save}>
           {isNew ? "Create type" : "Save"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/RelationTypeEditor.tsx
+++ b/app/src/components/settings/pages/RelationTypeEditor.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field, TextInput } from "../Field";
+import { type SettingsRelationType } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+/** Relationship-type detail/editor — opened from the list (list → detail). */
+export function RelationTypeEditor({
+  relationType,
+  onClose,
+}: {
+  relationType: SettingsRelationType | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = relationType === "new";
+  const base = isNew ? undefined : relationType;
+
+  const [name, setName] = useState(base?.name ?? "");
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: isNew ? "Relationship type created" : `${name || "Type"} saved`, type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Relationship types"]} title={isNew ? "New relationship type" : base!.name} />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-4 max-w-sm">
+          <Field label="Name" hint="The label shown when connecting two entities.">
+            <TextInput value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Represented by" />
+          </Field>
+          {!isNew && (
+            <p className="text-xs text-ink-tertiary">
+              Used by <span className="font-semibold text-ink-secondary tabular-nums">{base!.usageCount}</span> connections.
+            </p>
+          )}
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" disabled={!name} onClick={save}>
+          {isNew ? "Create type" : "Save"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/RelationTypesPage.tsx
+++ b/app/src/components/settings/pages/RelationTypesPage.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus, Spline } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { RelationTypeEditor } from "./RelationTypeEditor";
+import { seedRelationTypes, type SettingsRelationType } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+export function RelationTypesPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [types, setTypes] = useState<SettingsRelationType[]>(seedRelationTypes);
+  const [confirm, setConfirm] = useState<SettingsRelationType | null>(null);
+  const [editing, setEditing] = useState<SettingsRelationType | "new" | null>(null);
+
+  if (editing) return <RelationTypeEditor relationType={editing} onClose={() => setEditing(null)} />;
+
+  const columns: Column<SettingsRelationType>[] = [
+    {
+      id: "name",
+      header: "Relationship type",
+      cell: (r) => (
+        <div className="flex items-center gap-2">
+          <Spline size={14} className="text-ink-muted shrink-0" />
+          <span className="font-medium text-ink truncate">{r.name}</span>
+        </div>
+      ),
+    },
+    {
+      id: "usage",
+      header: "Used by",
+      width: "9rem",
+      cell: (r) => (
+        <span className="text-ink-secondary tabular-nums">
+          {r.usageCount} <span className="text-ink-tertiary">connections</span>
+        </span>
+      ),
+    },
+    {
+      id: "actions",
+      header: "",
+      width: "6rem",
+      align: "right",
+      cell: (r) => <RowActions label={r.name} onEdit={() => setEditing(r)} onDelete={() => setConfirm(r)} />,
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Relationship types" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          The labels available when connecting entities. Deleting a type re-labels its connections as
+          unlabeled.
+        </p>
+        <Table columns={columns} data={types} getRowId={(r) => r.id} onRowClick={(r) => setEditing(r)} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Plus size={14} />} onClick={() => setEditing("new")}>
+          Add type
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title="Delete relationship type"
+        message={`Delete “${confirm?.name}”? Its ${confirm?.usageCount} connections will be re-labeled as unlabeled.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirm) {
+            setTypes((prev) => prev.filter((r) => r.id !== confirm.id));
+            setToasts((p) => [...p, { id: Date.now().toString(), message: `${confirm.name} deleted`, type: "success" as const }]);
+          }
+          setConfirm(null);
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/TemplateEditor.tsx
+++ b/app/src/components/settings/pages/TemplateEditor.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus, GripVertical } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { Field, TextInput } from "../Field";
+import { Checkbox } from "../../shared/Checkbox";
+import {
+  templatePropertiesByTemplate,
+  defaultTemplateProperties,
+  propertyTypeLabels,
+  type SettingsTemplate,
+  type TemplateProperty,
+} from "../../../data/settings";
+import { entityTypes } from "../../../data/entities";
+import { toastsAtom } from "../../../atoms/references";
+
+const PALETTE = entityTypes.map((t) => t.color);
+
+/** Template detail/editor — name, colour, and the property list. Opened from
+ *  the Templates list (list → detail pattern). `onClose` returns to the list. */
+export function TemplateEditor({
+  template,
+  onClose,
+}: {
+  template: SettingsTemplate | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = template === "new";
+  const base = isNew ? undefined : template;
+
+  const [name, setName] = useState(base?.name ?? "");
+  const [color, setColor] = useState(base?.color ?? PALETTE[0]);
+  const [props, setProps] = useState<TemplateProperty[]>(
+    isNew ? [...defaultTemplateProperties] : templatePropertiesByTemplate[base!.id] ?? defaultTemplateProperties,
+  );
+
+  const patchProp = (id: string, patch: Partial<TemplateProperty>) =>
+    setProps((prev) => prev.map((p) => (p.id === id ? { ...p, ...patch } : p)));
+
+  const addProperty = () =>
+    setProps((prev) => [
+      ...prev,
+      { id: `np-${prev.length}-${name.length}`, label: "New property", type: "text", required: false, filterable: false },
+    ]);
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: isNew ? "Template created" : `${name || "Template"} saved`, type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  const columns: Column<TemplateProperty>[] = [
+    {
+      id: "label",
+      header: "Property",
+      cell: (p) => (
+        <div className="flex items-center gap-2 w-full">
+          <GripVertical size={14} className="text-ink-muted shrink-0 cursor-grab" />
+          <input
+            value={p.label}
+            onChange={(e) => patchProp(p.id, { label: e.target.value })}
+            className="flex-1 min-w-0 bg-transparent text-sm font-medium text-ink focus:outline-none focus:bg-warm rounded px-1 py-0.5"
+            aria-label="Property label"
+          />
+        </div>
+      ),
+    },
+    {
+      id: "type",
+      header: "Type",
+      width: "9rem",
+      cell: (p) => (
+        <span className="text-[11px] font-semibold text-ink-secondary bg-vellum px-2 py-0.5 rounded-md w-fit">
+          {propertyTypeLabels[p.type]}
+        </span>
+      ),
+    },
+    {
+      id: "required",
+      header: "Required",
+      width: "6rem",
+      align: "center",
+      cell: (p) => (
+        <Checkbox checked={p.required} onChange={(e) => patchProp(p.id, { required: e.target.checked })} ariaLabel={`${p.label} required`} />
+      ),
+    },
+    {
+      id: "filterable",
+      header: "Filter",
+      width: "5rem",
+      align: "center",
+      cell: (p) => (
+        <Checkbox checked={p.filterable} onChange={(e) => patchProp(p.id, { filterable: e.target.checked })} ariaLabel={`${p.label} filterable`} />
+      ),
+    },
+    {
+      id: "actions",
+      header: "",
+      width: "4rem",
+      align: "right",
+      cell: (p) => <RowActions label={p.label} onDelete={() => setProps((prev) => prev.filter((x) => x.id !== p.id))} />,
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Templates"]} title={isNew ? "New template" : base!.name} />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6">
+          <section className="grid sm:grid-cols-2 gap-3">
+            <Field label="Template name">
+              <TextInput value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Court Case" />
+            </Field>
+            <Field label="Colour">
+              <div className="flex items-center gap-1.5 flex-wrap pt-1">
+                {PALETTE.map((c) => (
+                  <button
+                    key={c}
+                    onClick={() => setColor(c)}
+                    aria-label={`Colour ${c}`}
+                    className={`w-6 h-6 rounded-md transition-transform ${color === c ? "ring-2 ring-offset-1 ring-ink scale-105" : "hover:scale-105"}`}
+                    style={{ backgroundColor: c }}
+                  />
+                ))}
+              </div>
+            </Field>
+          </section>
+
+          <section className="pt-6" style={{ borderTop: "1px solid var(--border-soft)" }}>
+            <div className="flex items-center justify-between gap-2 mb-3">
+              <h3 className="text-sm font-semibold text-ink">Properties</h3>
+              <Button variant="secondary" size="sm" icon={<Plus size={14} />} onClick={addProperty}>
+                Add property
+              </Button>
+            </div>
+            <Table columns={columns} data={props} getRowId={(p) => p.id} emptyState="No properties yet." />
+          </section>
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" onClick={save}>
+          {isNew ? "Create template" : "Save"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/TemplateEditor.tsx
+++ b/app/src/components/settings/pages/TemplateEditor.tsx
@@ -38,6 +38,15 @@ export function TemplateEditor({
     isNew ? [...defaultTemplateProperties] : templatePropertiesByTemplate[base!.id] ?? defaultTemplateProperties,
   );
 
+  const initialColor = base?.color ?? PALETTE[0];
+  const initialProps = isNew
+    ? defaultTemplateProperties
+    : templatePropertiesByTemplate[base!.id] ?? defaultTemplateProperties;
+  const dirty =
+    name !== (base?.name ?? "") ||
+    color !== initialColor ||
+    JSON.stringify(props) !== JSON.stringify(initialProps);
+
   const patchProp = (id: string, patch: Partial<TemplateProperty>) =>
     setProps((prev) => prev.map((p) => (p.id === id ? { ...p, ...patch } : p)));
 
@@ -110,7 +119,7 @@ export function TemplateEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Templates"]} title={isNew ? "New template" : base!.name} />
+      <SettingsContent.Header path={["Templates"]} title={isNew ? "New template" : base!.name} onBack={onClose} />
       <SettingsContent.Body>
         <div className="flex flex-col gap-6">
           <section className="grid sm:grid-cols-2 gap-3">
@@ -144,11 +153,11 @@ export function TemplateEditor({
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" onClick={save}>
-          {isNew ? "Create template" : "Save"}
-        </Button>
         <Button variant="ghost" size="sm" onClick={onClose}>
           Cancel
+        </Button>
+        <Button variant="success" size="sm" disabled={!dirty} onClick={save}>
+          {isNew ? "Create template" : "Save"}
         </Button>
       </SettingsContent.Footer>
     </SettingsContent>

--- a/app/src/components/settings/pages/TemplatesPage.tsx
+++ b/app/src/components/settings/pages/TemplatesPage.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { TemplateEditor } from "./TemplateEditor";
+import { seedTemplates, type SettingsTemplate } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+export function TemplatesPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [templates, setTemplates] = useState<SettingsTemplate[]>(seedTemplates);
+  const [confirm, setConfirm] = useState<SettingsTemplate | null>(null);
+  const [editing, setEditing] = useState<SettingsTemplate | "new" | null>(null);
+
+  if (editing) return <TemplateEditor template={editing} onClose={() => setEditing(null)} />;
+
+  const columns: Column<SettingsTemplate>[] = [
+    {
+      id: "name",
+      header: "Template",
+      cell: (t) => (
+        <div className="flex items-center gap-2">
+          <span className="w-2.5 h-2.5 rounded-[2px] shrink-0" style={{ backgroundColor: t.color }} />
+          <span className="font-medium text-ink truncate">{t.name}</span>
+          {t.isDefault && (
+            <span className="text-[10px] font-semibold text-carbon bg-carbon-tint px-1.5 py-px rounded w-fit">
+              Default
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      id: "properties",
+      header: "Properties",
+      width: "8rem",
+      cell: (t) => <span className="text-ink-secondary">{t.propertyCount}</span>,
+    },
+    {
+      id: "entities",
+      header: "Entities",
+      width: "7rem",
+      cell: (t) => <span className="text-ink-secondary tabular-nums">{t.entityCount}</span>,
+    },
+    {
+      id: "actions",
+      header: "",
+      width: "6rem",
+      align: "right",
+      cell: (t) => <RowActions label={t.name} onEdit={() => setEditing(t)} onDelete={() => setConfirm(t)} />,
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Templates" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Templates define the metadata properties an entity of each type can carry.
+        </p>
+        <Table columns={columns} data={templates} getRowId={(t) => t.id} onRowClick={(t) => setEditing(t)} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Plus size={14} />} onClick={() => setEditing("new")}>
+          Add template
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title="Delete template"
+        message={`Delete the ${confirm?.name} template? Entities using it won't be removed but will lose this template's properties.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirm) {
+            setTemplates((prev) => prev.filter((t) => t.id !== confirm.id));
+            setToasts((p) => [...p, { id: Date.now().toString(), message: `${confirm.name} deleted`, type: "success" as const }]);
+          }
+          setConfirm(null);
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/ThesauriPage.tsx
+++ b/app/src/components/settings/pages/ThesauriPage.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus, BookOpen } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { ThesaurusEditor } from "./ThesaurusEditor";
+import { seedThesauri, type SettingsThesaurus } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+export function ThesauriPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [thesauri, setThesauri] = useState<SettingsThesaurus[]>(seedThesauri);
+  const [confirm, setConfirm] = useState<SettingsThesaurus | null>(null);
+  const [editing, setEditing] = useState<SettingsThesaurus | "new" | null>(null);
+
+  if (editing) return <ThesaurusEditor thesaurus={editing} onClose={() => setEditing(null)} />;
+
+  const columns: Column<SettingsThesaurus>[] = [
+    {
+      id: "name",
+      header: "Thesaurus",
+      cell: (t) => (
+        <div className="flex items-center gap-2">
+          <BookOpen size={14} className="text-ink-muted shrink-0" />
+          <span className="font-medium text-ink truncate">{t.name}</span>
+        </div>
+      ),
+    },
+    {
+      id: "items",
+      header: "Items",
+      width: "8rem",
+      cell: (t) => <span className="text-ink-secondary tabular-nums">{t.itemCount}</span>,
+    },
+    {
+      id: "actions",
+      header: "",
+      width: "6rem",
+      align: "right",
+      cell: (t) => <RowActions label={t.name} onEdit={() => setEditing(t)} onDelete={() => setConfirm(t)} />,
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Thesauri" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Controlled vocabularies you can attach to template properties.
+        </p>
+        <Table columns={columns} data={thesauri} getRowId={(t) => t.id} onRowClick={(t) => setEditing(t)} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Plus size={14} />} onClick={() => setEditing("new")}>
+          Add thesaurus
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title="Delete thesaurus"
+        message={`Delete the ${confirm?.name} thesaurus? Properties using it will fall back to free text.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirm) {
+            setThesauri((prev) => prev.filter((t) => t.id !== confirm.id));
+            setToasts((p) => [...p, { id: Date.now().toString(), message: `${confirm.name} deleted`, type: "success" as const }]);
+          }
+          setConfirm(null);
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/ThesaurusEditor.tsx
+++ b/app/src/components/settings/pages/ThesaurusEditor.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus, GripVertical } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { Field, TextInput } from "../Field";
+import { seedThesaurusItems, type SettingsThesaurus } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+/** Thesaurus detail/editor — name + the editable item list (a thesaurus's
+ *  children). Opened from the Thesauri list (list → detail). */
+export function ThesaurusEditor({
+  thesaurus,
+  onClose,
+}: {
+  thesaurus: SettingsThesaurus | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = thesaurus === "new";
+  const base = isNew ? undefined : thesaurus;
+
+  const [name, setName] = useState(base?.name ?? "");
+  const [items, setItems] = useState<Item[]>(
+    isNew ? [] : (seedThesaurusItems[base!.id] ?? []).map((label, i) => ({ id: `i${i}`, label })),
+  );
+
+  const patch = (id: string, label: string) =>
+    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, label } : it)));
+  const addItem = () =>
+    setItems((prev) => [...prev, { id: `n-${prev.length}-${name.length}`, label: "" }]);
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: isNew ? "Thesaurus created" : `${name || "Thesaurus"} saved`, type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  const columns: Column<Item>[] = [
+    {
+      id: "label",
+      header: "Item",
+      cell: (it) => (
+        <div className="flex items-center gap-2 w-full">
+          <GripVertical size={14} className="text-ink-muted shrink-0 cursor-grab" />
+          <input
+            value={it.label}
+            onChange={(e) => patch(it.id, e.target.value)}
+            placeholder="Item label"
+            className="flex-1 min-w-0 bg-transparent text-sm text-ink focus:outline-none focus:bg-warm rounded px-1 py-0.5"
+            aria-label="Item label"
+          />
+        </div>
+      ),
+    },
+    {
+      id: "actions",
+      header: "",
+      width: "4rem",
+      align: "right",
+      cell: (it) => (
+        <RowActions label={it.label || "item"} onDelete={() => setItems((prev) => prev.filter((x) => x.id !== it.id))} />
+      ),
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Thesauri"]} title={isNew ? "New thesaurus" : base!.name} />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6">
+          <section className="max-w-sm">
+            <Field label="Thesaurus name">
+              <TextInput value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Violation types" />
+            </Field>
+          </section>
+
+          <section className="pt-6" style={{ borderTop: "1px solid var(--border-soft)" }}>
+            <div className="flex items-center justify-between gap-2 mb-3">
+              <h3 className="text-sm font-semibold text-ink">Items <span className="text-ink-tertiary font-normal">({items.length})</span></h3>
+              <Button variant="secondary" size="sm" icon={<Plus size={14} />} onClick={addItem}>
+                Add item
+              </Button>
+            </div>
+            <Table columns={columns} data={items} getRowId={(it) => it.id} emptyState="No items yet." />
+          </section>
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" disabled={!name} onClick={save}>
+          {isNew ? "Create thesaurus" : "Save"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/ThesaurusEditor.tsx
+++ b/app/src/components/settings/pages/ThesaurusEditor.tsx
@@ -32,6 +32,11 @@ export function ThesaurusEditor({
     isNew ? [] : (seedThesaurusItems[base!.id] ?? []).map((label, i) => ({ id: `i${i}`, label })),
   );
 
+  const initialLabels = isNew ? [] : seedThesaurusItems[base!.id] ?? [];
+  const dirty =
+    name !== (base?.name ?? "") ||
+    JSON.stringify(items.map((i) => i.label)) !== JSON.stringify(initialLabels);
+
   const patch = (id: string, label: string) =>
     setItems((prev) => prev.map((it) => (it.id === id ? { ...it, label } : it)));
   const addItem = () =>
@@ -75,7 +80,7 @@ export function ThesaurusEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Thesauri"]} title={isNew ? "New thesaurus" : base!.name} />
+      <SettingsContent.Header path={["Thesauri"]} title={isNew ? "New thesaurus" : base!.name} onBack={onClose} />
       <SettingsContent.Body>
         <div className="flex flex-col gap-6">
           <section className="max-w-sm">
@@ -96,10 +101,10 @@ export function ThesaurusEditor({
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" disabled={!name} onClick={save}>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button variant="success" size="sm" disabled={!dirty || !name} onClick={save}>
           {isNew ? "Create thesaurus" : "Save"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/TranslationEditor.tsx
+++ b/app/src/components/settings/pages/TranslationEditor.tsx
@@ -43,6 +43,8 @@ export function TranslationEditor({
       prev.map((r, i) => (i === rowIndex ? { ...r, values: { ...r.values, [langKey]: value } } : r)),
     );
 
+  const dirty = JSON.stringify(rows) !== JSON.stringify(buildRows(context));
+
   const save = () => {
     setToasts((p) => [
       ...p,
@@ -91,7 +93,7 @@ export function TranslationEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Translations"]} title={context.name} />
+      <SettingsContent.Header path={["Translations"]} title={context.name} onBack={onClose} />
       <SettingsContent.Body>
         <p className="text-xs text-ink-tertiary mb-4">
           Translate each term into your active languages. The source language is shown for reference.
@@ -99,11 +101,11 @@ export function TranslationEditor({
         <Table columns={columns} data={rows} getRowId={(r) => r.key} />
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" onClick={save}>
-          Save
-        </Button>
         <Button variant="ghost" size="sm" onClick={onClose}>
           Cancel
+        </Button>
+        <Button variant="success" size="sm" disabled={!dirty} onClick={save}>
+          Save
         </Button>
       </SettingsContent.Footer>
     </SettingsContent>

--- a/app/src/components/settings/pages/TranslationEditor.tsx
+++ b/app/src/components/settings/pages/TranslationEditor.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import {
+  seedLanguages,
+  seedTranslationKeys,
+  type SettingsTranslationContext,
+  type TranslationKey,
+} from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+/** Build the editable rows for a context — seeded terms when we have them, else
+ *  a representative set generated from the context's key count. */
+function buildRows(context: SettingsTranslationContext): TranslationKey[] {
+  const seeded = seedTranslationKeys[context.id];
+  if (seeded) return seeded.map((r) => ({ key: r.key, values: { ...r.values } }));
+  const n = Math.min(context.keyCount, 10);
+  return Array.from({ length: n }, (_, i) => ({
+    key: `${context.name} term ${i + 1}`,
+    values: Object.fromEntries(
+      seedLanguages.map((l) => [l.key, l.default ? `${context.name} term ${i + 1}` : ""]),
+    ),
+  }));
+}
+
+/** Per-context translation editor — a key × language grid, opened from the
+ *  Translations list (list → detail). The default language column is read-only
+ *  (it's the source term); the rest are editable. */
+export function TranslationEditor({
+  context,
+  onClose,
+}: {
+  context: SettingsTranslationContext;
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const [rows, setRows] = useState<TranslationKey[]>(() => buildRows(context));
+
+  const patch = (rowIndex: number, langKey: string, value: string) =>
+    setRows((prev) =>
+      prev.map((r, i) => (i === rowIndex ? { ...r, values: { ...r.values, [langKey]: value } } : r)),
+    );
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: `${context.name} translations saved`, type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  const columns: Column<TranslationKey>[] = [
+    {
+      id: "key",
+      header: "Term",
+      width: "14rem",
+      cell: (r) => <span className="text-xs font-medium text-ink truncate">{r.key}</span>,
+    },
+    ...seedLanguages.map<Column<TranslationKey>>((lang) => ({
+      id: lang.key,
+      width: "14rem",
+      header: (
+        <span className="flex items-center gap-1.5">
+          {lang.label}
+          {lang.default && (
+            <span className="text-[9px] font-semibold text-carbon bg-carbon-tint px-1 py-px rounded normal-case">
+              Source
+            </span>
+          )}
+        </span>
+      ),
+      cell: (r, i) =>
+        lang.default ? (
+          <span className="text-sm text-ink-tertiary truncate" dir={lang.ltr ? "ltr" : "rtl"}>
+            {r.values[lang.key] || "—"}
+          </span>
+        ) : (
+          <input
+            value={r.values[lang.key] ?? ""}
+            onChange={(e) => patch(i, lang.key, e.target.value)}
+            dir={lang.ltr ? "ltr" : "rtl"}
+            placeholder="Add translation…"
+            aria-label={`${r.key} in ${lang.label}`}
+            className="w-full min-w-0 bg-transparent text-sm text-ink focus:outline-none focus:bg-warm rounded px-1.5 py-1 placeholder:text-ink-muted"
+          />
+        ),
+    })),
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Translations"]} title={context.name} />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Translate each term into your active languages. The source language is shown for reference.
+        </p>
+        <Table columns={columns} data={rows} getRowId={(r) => r.key} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" onClick={save}>
+          Save
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/TranslationsPage.tsx
+++ b/app/src/components/settings/pages/TranslationsPage.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { Upload } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { TranslationEditor } from "./TranslationEditor";
+import { seedTranslationContexts, type SettingsTranslationContext } from "../../../data/settings";
+
+const typeStyle: Record<SettingsTranslationContext["type"], string> = {
+  System: "bg-carbon-tint text-carbon",
+  Template: "bg-warm text-ink-secondary",
+  Thesaurus: "bg-warm text-ink-secondary",
+  Menu: "bg-warm text-ink-secondary",
+};
+
+export function TranslationsPage() {
+  const [editing, setEditing] = useState<SettingsTranslationContext | null>(null);
+
+  if (editing) return <TranslationEditor context={editing} onClose={() => setEditing(null)} />;
+
+  const columns: Column<SettingsTranslationContext>[] = [
+    {
+      id: "name",
+      header: "Context",
+      cell: (c) => <span className="font-medium text-ink truncate">{c.name}</span>,
+    },
+    {
+      id: "type",
+      header: "Type",
+      width: "9rem",
+      cell: (c) => (
+        <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-md w-fit ${typeStyle[c.type]}`}>
+          {c.type}
+        </span>
+      ),
+    },
+    {
+      id: "keys",
+      header: "Keys",
+      width: "6rem",
+      cell: (c) => <span className="text-ink-secondary tabular-nums">{c.keyCount}</span>,
+    },
+    {
+      id: "actions",
+      header: "",
+      width: "7rem",
+      align: "right",
+      cell: (c) => (
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            setEditing(c);
+          }}
+        >
+          Translate
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Translations" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Translate the interface and your collection's content across active languages.
+        </p>
+        <Table columns={columns} data={seedTranslationContexts} getRowId={(c) => c.id} onRowClick={(c) => setEditing(c)} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="secondary" size="sm" icon={<Upload size={14} />}>
+          Import translations (CSV)
+        </Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/UploadsPage.tsx
+++ b/app/src/components/settings/pages/UploadsPage.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Upload, Image, FileText, Type, File } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { RowActions } from "../RowActions";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { seedUploads, type SettingsUpload } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+const typeIcon = { image: Image, pdf: FileText, font: Type, other: File };
+
+export function UploadsPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [uploads, setUploads] = useState<SettingsUpload[]>(seedUploads);
+  const [confirm, setConfirm] = useState<SettingsUpload | null>(null);
+
+  const columns: Column<SettingsUpload>[] = [
+    {
+      id: "name",
+      header: "File",
+      cell: (u) => {
+        const Icon = typeIcon[u.type];
+        return (
+          <div className="flex items-center gap-2 min-w-0">
+            <Icon size={14} className="text-ink-muted shrink-0" />
+            <span className="font-medium text-ink truncate">{u.name}</span>
+          </div>
+        );
+      },
+    },
+    { id: "url", header: "URL", cell: (u) => <span dir="ltr" className="text-xs text-ink-tertiary truncate">{u.url}</span> },
+    { id: "size", header: "Size", width: "7rem", cell: (u) => <span dir="ltr" className="text-xs text-ink-tertiary">{u.size}</span> },
+    { id: "actions", header: "", width: "6rem", align: "right", cell: (u) => <RowActions label={u.name} onDelete={() => setConfirm(u)} /> },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Uploads" />
+      <SettingsContent.Body>
+        <p className="text-xs text-ink-tertiary mb-4">
+          Assets you can reference from pages, custom CSS, or templates.
+        </p>
+        <Table columns={columns} data={uploads} getRowId={(u) => u.id} />
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" icon={<Upload size={14} />}>
+          Upload file
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title="Delete upload"
+        message={`Delete “${confirm?.name}”? References to its URL will break.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirm) {
+            setUploads((prev) => prev.filter((u) => u.id !== confirm.id));
+            setToasts((p) => [...p, { id: Date.now().toString(), message: `${confirm.name} deleted`, type: "success" as const }]);
+          }
+          setConfirm(null);
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/UserEditor.tsx
+++ b/app/src/components/settings/pages/UserEditor.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { ShieldCheck } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Field, TextInput } from "../Field";
+import { RadioGroup } from "../../shared/RadioGroup";
+import { Checkbox } from "../../shared/Checkbox";
+import { seedGroups, type SettingsUser, type UserRole } from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+const ROLE_OPTIONS = [
+  { id: "admin", label: "Admin", hint: "Full access to settings and content." },
+  { id: "editor", label: "Editor", hint: "Create and edit content; no settings." },
+  { id: "collaborator", label: "Collaborator", hint: "Comment and suggest only." },
+];
+
+/** User detail/editor — opened from the Users list (list → detail). */
+export function UserEditor({
+  user,
+  onClose,
+}: {
+  user: SettingsUser | "new";
+  onClose: () => void;
+}) {
+  const setToasts = useSetAtom(toastsAtom);
+  const isNew = user === "new";
+  const base = isNew ? undefined : user;
+
+  const [username, setUsername] = useState(base?.username ?? "");
+  const [email, setEmail] = useState(base?.email ?? "");
+  const [role, setRole] = useState<UserRole>(base?.role ?? "collaborator");
+  const [groups, setGroups] = useState<string[]>(base?.groups ?? []);
+
+  const toggleGroup = (name: string) =>
+    setGroups((prev) => (prev.includes(name) ? prev.filter((g) => g !== name) : [...prev, name]));
+
+  const save = () => {
+    setToasts((p) => [
+      ...p,
+      { id: Date.now().toString(), message: isNew ? "User invited" : `${username || "User"} saved`, type: "success" as const },
+    ]);
+    onClose();
+  };
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header path={["Users & Groups"]} title={isNew ? "New user" : base!.username} />
+      <SettingsContent.Body>
+        <div className="flex flex-col gap-6">
+          <section className="grid sm:grid-cols-2 gap-3">
+            <Field label="Username">
+              <TextInput value={username} onChange={(e) => setUsername(e.target.value)} placeholder="e.g. jdoe" />
+            </Field>
+            <Field label="Email">
+              <TextInput type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="name@org.example" />
+            </Field>
+          </section>
+
+          <section className="pt-6" style={{ borderTop: "1px solid var(--border-soft)" }}>
+            <h3 className="text-sm font-semibold text-ink mb-1">Role</h3>
+            <p className="text-xs text-ink-tertiary mb-3">What this user can do in the collection.</p>
+            <RadioGroup
+              name="user-role"
+              ariaLabel="Role"
+              value={role}
+              onChange={(v) => setRole(v as UserRole)}
+              options={ROLE_OPTIONS}
+            />
+          </section>
+
+          <section className="pt-6" style={{ borderTop: "1px solid var(--border-soft)" }}>
+            <h3 className="text-sm font-semibold text-ink mb-3">Groups</h3>
+            <div className="flex flex-col gap-2">
+              {seedGroups.map((g) => (
+                <label
+                  key={g.id}
+                  className="flex items-center gap-3 rounded-lg border border-border bg-paper px-3 py-2.5 cursor-pointer hover:bg-warm transition-colors"
+                >
+                  <Checkbox checked={groups.includes(g.name)} onChange={() => toggleGroup(g.name)} ariaLabel={g.name} />
+                  <span className="text-sm font-medium text-ink flex-1">{g.name}</span>
+                  <span className="text-xs text-ink-tertiary">{g.memberCount} members</span>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          {!isNew && (
+            <section className="pt-6" style={{ borderTop: "1px solid var(--border-soft)" }}>
+              <h3 className="text-sm font-semibold text-ink mb-3">Two-factor authentication</h3>
+              <div className="flex items-center gap-3 rounded-lg border border-border bg-paper px-4 py-3">
+                <span className="flex items-center justify-center w-8 h-8 rounded-md bg-success-light shrink-0">
+                  <ShieldCheck size={16} className="text-success" />
+                </span>
+                <p className="text-sm text-ink flex-1 min-w-0">
+                  {base!.using2fa ? "2FA is enabled for this account." : "This account has not enabled 2FA."}
+                </p>
+                <Button variant="secondary" size="sm">Reset</Button>
+              </div>
+            </section>
+          )}
+        </div>
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button variant="primary" size="sm" disabled={!username || !email} onClick={save}>
+          {isNew ? "Invite user" : "Save"}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+      </SettingsContent.Footer>
+    </SettingsContent>
+  );
+}

--- a/app/src/components/settings/pages/UserEditor.tsx
+++ b/app/src/components/settings/pages/UserEditor.tsx
@@ -32,6 +32,12 @@ export function UserEditor({
   const [role, setRole] = useState<UserRole>(base?.role ?? "collaborator");
   const [groups, setGroups] = useState<string[]>(base?.groups ?? []);
 
+  const dirty =
+    username !== (base?.username ?? "") ||
+    email !== (base?.email ?? "") ||
+    role !== (base?.role ?? "collaborator") ||
+    JSON.stringify(groups) !== JSON.stringify(base?.groups ?? []);
+
   const toggleGroup = (name: string) =>
     setGroups((prev) => (prev.includes(name) ? prev.filter((g) => g !== name) : [...prev, name]));
 
@@ -45,7 +51,7 @@ export function UserEditor({
 
   return (
     <SettingsContent>
-      <SettingsContent.Header path={["Users & Groups"]} title={isNew ? "New user" : base!.username} />
+      <SettingsContent.Header path={["Users & Groups"]} title={isNew ? "New user" : base!.username} onBack={onClose} />
       <SettingsContent.Body>
         <div className="flex flex-col gap-6">
           <section className="grid sm:grid-cols-2 gap-3">
@@ -102,10 +108,10 @@ export function UserEditor({
         </div>
       </SettingsContent.Body>
       <SettingsContent.Footer>
-        <Button variant="primary" size="sm" disabled={!username || !email} onClick={save}>
+        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+        <Button variant="success" size="sm" disabled={!dirty || !username || !email} onClick={save}>
           {isNew ? "Invite user" : "Save"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
       </SettingsContent.Footer>
     </SettingsContent>
   );

--- a/app/src/components/settings/pages/UsersPage.tsx
+++ b/app/src/components/settings/pages/UsersPage.tsx
@@ -1,0 +1,220 @@
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Plus, Pencil, Trash2, ShieldCheck } from "lucide-react";
+import { SettingsContent } from "../SettingsContent";
+import { Button } from "../Button";
+import { Table, type Column } from "../Table";
+import { DrawerTabs } from "../../layout/DrawerTabs";
+import { ConfirmDialog } from "../../shared/ConfirmDialog";
+import { UserEditor } from "./UserEditor";
+import { GroupEditor } from "./GroupEditor";
+import {
+  seedUsers,
+  seedGroups,
+  type SettingsUser,
+  type SettingsGroupRecord,
+  type UserRole,
+} from "../../../data/settings";
+import { toastsAtom } from "../../../atoms/references";
+
+const roleStyle: Record<UserRole, string> = {
+  admin: "bg-seal-tint text-seal",
+  editor: "bg-carbon-tint text-carbon",
+  collaborator: "bg-warm text-ink-secondary",
+};
+
+export function UsersPage() {
+  const setToasts = useSetAtom(toastsAtom);
+  const [tab, setTab] = useState<"users" | "groups">("users");
+  const [users, setUsers] = useState<SettingsUser[]>(seedUsers);
+  const [groups, setGroups] = useState<SettingsGroupRecord[]>(seedGroups);
+  const [confirmUser, setConfirmUser] = useState<SettingsUser | null>(null);
+  const [confirmGroup, setConfirmGroup] = useState<SettingsGroupRecord | null>(null);
+  const [editingUser, setEditingUser] = useState<SettingsUser | "new" | null>(null);
+  const [editingGroup, setEditingGroup] = useState<SettingsGroupRecord | "new" | null>(null);
+
+  if (editingUser) return <UserEditor user={editingUser} onClose={() => setEditingUser(null)} />;
+  if (editingGroup) return <GroupEditor group={editingGroup} onClose={() => setEditingGroup(null)} />;
+
+  const toast = (message: string) =>
+    setToasts((prev) => [...prev, { id: Date.now().toString(), message, type: "success" as const }]);
+
+  const userColumns: Column<SettingsUser>[] = [
+    {
+      id: "user",
+      header: "User",
+      cell: (u) => (
+        <div className="flex items-center gap-2.5">
+          <span className="flex items-center justify-center w-7 h-7 rounded-md bg-vellum text-[11px] font-semibold text-ink-secondary uppercase shrink-0">
+            {u.username.slice(0, 2)}
+          </span>
+          <div className="min-w-0">
+            <p className="font-medium text-ink truncate">{u.username}</p>
+            <p className="text-xs text-ink-tertiary truncate">{u.email}</p>
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: "role",
+      header: "Role",
+      width: "8rem",
+      cell: (u) => (
+        <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-md w-fit capitalize ${roleStyle[u.role]}`}>
+          {u.role}
+        </span>
+      ),
+    },
+    {
+      id: "groups",
+      header: "Groups",
+      cell: (u) =>
+        u.groups.length === 0 ? (
+          <span className="text-ink-muted">—</span>
+        ) : (
+          <div className="flex flex-wrap gap-1">
+            {u.groups.map((g) => (
+              <span key={g} className="text-[11px] text-ink-secondary bg-warm px-1.5 py-0.5 rounded w-fit">
+                {g}
+              </span>
+            ))}
+          </div>
+        ),
+    },
+    {
+      id: "2fa",
+      header: "2FA",
+      align: "center",
+      width: "4rem",
+      cell: (u) =>
+        u.using2fa ? (
+          <ShieldCheck size={15} className="text-success mx-auto" />
+        ) : (
+          <span className="text-ink-muted">—</span>
+        ),
+    },
+    {
+      id: "actions",
+      header: "",
+      align: "right",
+      width: "6rem",
+      cell: (u) => (
+        <div className="flex items-center justify-end gap-1">
+          <button
+            onClick={(e) => { e.stopPropagation(); setEditingUser(u); }}
+            aria-label={`Edit ${u.username}`}
+            className="p-1.5 rounded-md text-ink-tertiary hover:bg-warm hover:text-ink transition-colors cursor-pointer"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); setConfirmUser(u); }}
+            aria-label={`Delete ${u.username}`}
+            className="p-1.5 rounded-md text-ink-tertiary hover:bg-seal-tint hover:text-seal transition-colors cursor-pointer"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  const groupColumns: Column<SettingsGroupRecord>[] = [
+    { id: "name", header: "Group", cell: (g) => <span className="font-medium text-ink">{g.name}</span> },
+    {
+      id: "members",
+      header: "Members",
+      width: "8rem",
+      cell: (g) => <span className="text-ink-secondary">{g.memberCount}</span>,
+    },
+    {
+      id: "actions",
+      header: "",
+      align: "right",
+      width: "6rem",
+      cell: (g) => (
+        <div className="flex items-center justify-end gap-1">
+          <button
+            onClick={(e) => { e.stopPropagation(); setEditingGroup(g); }}
+            aria-label={`Edit ${g.name}`}
+            className="p-1.5 rounded-md text-ink-tertiary hover:bg-warm hover:text-ink transition-colors cursor-pointer"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); setConfirmGroup(g); }}
+            aria-label={`Delete ${g.name}`}
+            className="p-1.5 rounded-md text-ink-tertiary hover:bg-seal-tint hover:text-seal transition-colors cursor-pointer"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <SettingsContent>
+      <SettingsContent.Header title="Users & Groups" />
+      <SettingsContent.Body>
+        <div className="mb-4">
+          <DrawerTabs
+            className=""
+            activeId={tab}
+            onChange={(v) => setTab(v as "users" | "groups")}
+            tabs={[
+              { id: "users", label: "Users", count: users.length },
+              { id: "groups", label: "Groups", count: groups.length },
+            ]}
+          />
+        </div>
+        {tab === "users" ? (
+          <Table columns={userColumns} data={users} getRowId={(u) => u.id} onRowClick={(u) => setEditingUser(u)} />
+        ) : (
+          <Table columns={groupColumns} data={groups} getRowId={(g) => g.id} onRowClick={(g) => setEditingGroup(g)} />
+        )}
+      </SettingsContent.Body>
+      <SettingsContent.Footer>
+        <Button
+          variant="primary"
+          size="sm"
+          icon={<Plus size={14} />}
+          onClick={() => (tab === "users" ? setEditingUser("new") : setEditingGroup("new"))}
+        >
+          {tab === "users" ? "Add user" : "Add group"}
+        </Button>
+      </SettingsContent.Footer>
+
+      <ConfirmDialog
+        open={confirmUser !== null}
+        title="Delete user"
+        message={`Delete ${confirmUser?.username}? They will lose access to this collection.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirmUser) {
+            setUsers((prev) => prev.filter((u) => u.id !== confirmUser.id));
+            toast(`${confirmUser.username} deleted`);
+          }
+          setConfirmUser(null);
+        }}
+        onCancel={() => setConfirmUser(null)}
+      />
+      <ConfirmDialog
+        open={confirmGroup !== null}
+        title="Delete group"
+        message={`Delete the ${confirmGroup?.name} group? Members keep their accounts.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirmGroup) {
+            setGroups((prev) => prev.filter((g) => g.id !== confirmGroup.id));
+            toast(`${confirmGroup.name} deleted`);
+          }
+          setConfirmGroup(null);
+        }}
+        onCancel={() => setConfirmGroup(null)}
+      />
+    </SettingsContent>
+  );
+}

--- a/app/src/components/shared/DataTable.tsx
+++ b/app/src/components/shared/DataTable.tsx
@@ -1,0 +1,132 @@
+import type { ReactNode } from "react";
+
+export interface Column<T> {
+  id: string;
+  header: ReactNode;
+  cell: (row: T, index: number) => ReactNode;
+  /** Grid track width (e.g. "1fr", "8rem", "70px"). Default "1fr". */
+  width?: string;
+  align?: "left" | "center" | "right";
+}
+
+interface DataTableProps<T> {
+  columns: Column<T>[];
+  data: T[];
+  getRowId: (row: T) => string;
+  onRowClick?: (row: T) => void;
+  /** Highlight predicate (bg-parchment). Use for focus/selection. */
+  isRowSelected?: (row: T) => boolean;
+  emptyState?: ReactNode;
+  /** Optional bottom strip (e.g. a count). Renders the warm footer bar. */
+  footer?: ReactNode;
+  /** When set, the grid gets this min-width (rem) and scrolls horizontally
+   *  below it instead of squishing. Omit for tables whose columns always fit. */
+  minWidthRem?: number;
+}
+
+const alignClass = {
+  left: "",
+  center: "justify-center text-center",
+  right: "justify-end text-right",
+} as const;
+
+const CARD_SHADOW = "0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06)";
+
+/** The app's canonical data table — the entity-view Files table style, made
+ *  generic via a declarative column API: a paper card with a soft shadow, a
+ *  warm uppercase header strip, h-11 rows (hover:bg-warm, selected
+ *  bg-parchment), and an optional warm footer. Reused across the Files view and
+ *  every Settings list so they share one visual language. */
+export function DataTable<T>({
+  columns,
+  data,
+  getRowId,
+  onRowClick,
+  isRowSelected,
+  emptyState,
+  footer,
+  minWidthRem,
+}: DataTableProps<T>) {
+  const gridTemplateColumns = columns.map((c) => c.width ?? "1fr").join(" ");
+  const scrolls = minWidthRem !== undefined;
+
+  return (
+    <div
+      className={`rounded-md bg-paper ${scrolls ? "overflow-x-auto" : "overflow-hidden"}`}
+      style={{ boxShadow: CARD_SHADOW }}
+    >
+      <div style={scrolls ? { minWidth: `${minWidthRem}rem` } : undefined}>
+        {/* Header */}
+        <div
+          className="grid items-center gap-3 px-4 h-10 text-[11px] font-semibold text-ink-tertiary uppercase tracking-wider"
+          style={{
+            gridTemplateColumns,
+            backgroundColor: "var(--bg-warm)",
+            borderBottom: "1px solid var(--border-primary)",
+          }}
+        >
+          {columns.map((col) => (
+            <div key={col.id} className={`flex items-center min-w-0 ${alignClass[col.align ?? "left"]}`}>
+              {col.header}
+            </div>
+          ))}
+        </div>
+
+        {/* Rows */}
+        {data.length === 0 ? (
+          <div className="px-4 py-10 text-center text-xs text-ink-muted">
+            {emptyState ?? "Nothing here yet."}
+          </div>
+        ) : (
+          data.map((row, i) => {
+            const id = getRowId(row);
+            const selected = isRowSelected?.(row) ?? false;
+            const clickable = !!onRowClick;
+            return (
+              <div
+                key={id}
+                role={clickable ? "button" : "row"}
+                tabIndex={clickable ? 0 : undefined}
+                aria-pressed={clickable ? selected : undefined}
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                onKeyDown={
+                  clickable
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onRowClick!(row);
+                        }
+                      }
+                    : undefined
+                }
+                className={`group grid items-center gap-3 px-4 min-h-11 py-2 text-sm transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ink/20 ${
+                  clickable ? "cursor-pointer" : ""
+                } ${selected ? "bg-parchment" : "hover:bg-warm"}`}
+                style={{ gridTemplateColumns, borderBottom: "1px solid var(--border-primary)" }}
+              >
+                {columns.map((col) => (
+                  <div
+                    key={col.id}
+                    className={`flex items-center min-w-0 text-ink ${alignClass[col.align ?? "left"]}`}
+                  >
+                    {col.cell(row, i)}
+                  </div>
+                ))}
+              </div>
+            );
+          })
+        )}
+
+        {/* Footer */}
+        {footer !== undefined && (
+          <div
+            className="flex items-center justify-between px-4 h-10 text-xs text-ink-muted"
+            style={{ backgroundColor: "var(--bg-warm)", borderTop: "1px solid var(--border-primary)" }}
+          >
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/shared/RadioGroup.tsx
+++ b/app/src/components/shared/RadioGroup.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+
+export interface RadioOption {
+  id: string;
+  label: string;
+  hint?: string;
+  icon?: ReactNode;
+}
+
+interface RadioGroupProps {
+  name: string;
+  value: string;
+  options: RadioOption[];
+  onChange: (id: string) => void;
+  ariaLabel?: string;
+  /** Lay the options out in a row instead of stacking them. */
+  inline?: boolean;
+}
+
+/** A single-choice control. Native radio inputs (accent-ink, like Checkbox)
+ *  with a label + optional hint, selectable by clicking the whole row. Use for
+ *  picking one setting value — not for navigation (that's tabs). */
+export function RadioGroup({
+  name,
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  inline = false,
+}: RadioGroupProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={inline ? "flex flex-wrap gap-2" : "flex flex-col gap-2"}
+    >
+      {options.map((opt) => {
+        const checked = value === opt.id;
+        return (
+          <label
+            key={opt.id}
+            className={`flex items-start gap-2.5 rounded-lg border bg-paper px-3 py-2.5 cursor-pointer transition-colors ${
+              checked ? "border-ink" : "border-border hover:bg-warm"
+            } ${inline ? "flex-1 min-w-[8rem]" : ""}`}
+          >
+            <input
+              type="radio"
+              name={name}
+              checked={checked}
+              onChange={() => onChange(opt.id)}
+              aria-label={opt.label}
+              className="w-3.5 h-3.5 mt-0.5 accent-ink cursor-pointer shrink-0"
+            />
+            <span className="min-w-0">
+              <span className="flex items-center gap-1.5 text-sm font-medium text-ink">
+                {opt.icon}
+                {opt.label}
+              </span>
+              {opt.hint && <span className="block text-xs text-ink-tertiary">{opt.hint}</span>}
+            </span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/src/components/shared/SegmentedControl.tsx
+++ b/app/src/components/shared/SegmentedControl.tsx
@@ -29,7 +29,7 @@ export function SegmentedControl({
     <div
       role="group"
       aria-label={ariaLabel}
-      className={`flex items-center rounded-md overflow-hidden ${h}`}
+      className={`inline-flex w-fit items-center rounded-md overflow-hidden ${h}`}
       style={{ border: "1px solid var(--border-primary)" }}
     >
       {options.map((opt, i) => {

--- a/app/src/components/viewer/DocumentViewer.tsx
+++ b/app/src/components/viewer/DocumentViewer.tsx
@@ -30,9 +30,12 @@ interface DocumentViewerProps {
    *  active primary + language atoms. Used by the drawer's inline viewer
    *  to display any file the user "View"s without disturbing global state. */
   fileOverride?: { url?: string; language: string } | null;
+  /** Drop the bottom pager action bar — for hosts that supply their own
+   *  footer (the library preview's Close / View entity bar). */
+  hideActionBar?: boolean;
 }
 
-export function DocumentViewer({ actionBarMenu, showMinimap = true, fileOverride }: DocumentViewerProps = {}) {
+export function DocumentViewer({ actionBarMenu, showMinimap = true, fileOverride, hideActionBar = false }: DocumentViewerProps = {}) {
   const [breakpoint] = useAtom(breakpointAtom);
   const isMobile = breakpoint === "mobile";
   const [numPages, setNumPages] = useState<number>(0);
@@ -110,21 +113,41 @@ export function DocumentViewer({ actionBarMenu, showMinimap = true, fileOverride
     const range = sel.getRangeAt(0);
     const rect = range.getBoundingClientRect();
 
-    // Find which page this selection is in
+    // Find which page this selection is in, and convert the screen rect into
+    // page-relative (0-1) coords so highlights / references paint at the right
+    // spot regardless of zoom or page size.
     let page = currentPage;
+    let pageRelRect = { top: 0, left: 0, width: 0, height: 0 };
+    let pageRelRects: { top: number; left: number; width: number; height: number }[] = [];
     const anchorNode = sel.anchorNode;
     if (anchorNode) {
       const pageEl = (anchorNode instanceof HTMLElement ? anchorNode : anchorNode.parentElement)
         ?.closest("[data-page-number]");
       if (pageEl) {
         page = parseInt(pageEl.getAttribute("data-page-number") || "1", 10);
+        const pageRect = pageEl.getBoundingClientRect();
+        if (pageRect.width > 0 && pageRect.height > 0) {
+          const norm = (r: DOMRect) => ({
+            top: (r.top - pageRect.top) / pageRect.height,
+            left: (r.left - pageRect.left) / pageRect.width,
+            width: r.width / pageRect.width,
+            height: r.height / pageRect.height,
+          });
+          pageRelRect = norm(rect);
+          // Exact per-line boxes the browser computed for the selection — drop
+          // zero-area fragments the text layer sometimes emits.
+          pageRelRects = Array.from(range.getClientRects())
+            .filter((r) => r.width > 1 && r.height > 1)
+            .map(norm);
+        }
       }
     }
 
     setSelection({
       text,
       page,
-      rect: { top: 0, left: 0, width: 0, height: 0 },
+      rect: pageRelRect,
+      rects: pageRelRects,
       screenX: rect.left + rect.width / 2,
       screenY: rect.top,
     });
@@ -264,7 +287,7 @@ export function DocumentViewer({ actionBarMenu, showMinimap = true, fileOverride
       {/* Bottom action bar — only on the main-pane viewer (no fileOverride).
           When the viewer is mounted inside a drawer to preview a specific
           file, the host drawer carries its own footer (Back / Download). */}
-      {!fileOverride && (
+      {!fileOverride && !hideActionBar && (
         <ActionBar numPages={numPages} onScrollToPage={scrollToPage} rightSlot={actionBarMenu} showPager={!renditionMode} />
       )}
 

--- a/app/src/components/viewer/FloatingMenu.tsx
+++ b/app/src/components/viewer/FloatingMenu.tsx
@@ -1,6 +1,9 @@
 import { Link2, Copy, Highlighter } from "lucide-react";
-import { useSetAtom } from "jotai";
-import { entityPickerOpenAtom } from "../../atoms/selection";
+import { useAtomValue, useSetAtom } from "jotai";
+import { entityPickerOpenAtom, textSelectionAtom } from "../../atoms/selection";
+import { focusedEntityIdAtom } from "../../atoms/focusedEntity";
+import { highlightsAtom, HIGHLIGHT_COLOR } from "../../atoms/highlights";
+import { toastsAtom } from "../../atoms/references";
 import { t } from "../../utils/i18n";
 
 interface FloatingMenuProps {
@@ -11,6 +14,11 @@ interface FloatingMenuProps {
 
 export function FloatingMenu({ x, y, text }: FloatingMenuProps) {
   const setEntityPickerOpen = useSetAtom(entityPickerOpenAtom);
+  const selection = useAtomValue(textSelectionAtom);
+  const focusedEntityId = useAtomValue(focusedEntityIdAtom);
+  const setHighlights = useSetAtom(highlightsAtom);
+  const setSelection = useSetAtom(textSelectionAtom);
+  const setToasts = useSetAtom(toastsAtom);
 
   const handleCreateRef = () => {
     setEntityPickerOpen(true);
@@ -18,6 +26,28 @@ export function FloatingMenu({ x, y, text }: FloatingMenuProps) {
 
   const handleCopy = () => {
     navigator.clipboard.writeText(text);
+  };
+
+  const handleHighlight = () => {
+    if (!selection || selection.rects.length === 0) return;
+    setHighlights((prev) => [
+      ...prev,
+      {
+        id: `hl-${Date.now()}`,
+        entityId: focusedEntityId,
+        text: selection.text,
+        page: selection.page,
+        rects: selection.rects,
+        color: HIGHLIGHT_COLOR,
+        createdAt: new Date().toISOString().split("T")[0],
+      },
+    ]);
+    setToasts((prev) => [
+      ...prev,
+      { id: Date.now().toString(), message: t("System", "Highlight added"), type: "success" as const },
+    ]);
+    setSelection(null);
+    window.getSelection()?.removeAllRanges();
   };
 
   // Clamp horizontally so the menu doesn't escape the viewport
@@ -52,6 +82,7 @@ export function FloatingMenu({ x, y, text }: FloatingMenuProps) {
           <Copy size={14} />
         </button>
         <button
+          onClick={handleHighlight}
           className="p-1.5 text-white/70 rounded-md hover:bg-white/15 hover:text-white transition-colors"
           aria-label={t("System", "Highlight text")}
         >

--- a/app/src/components/viewer/PageHighlights.tsx
+++ b/app/src/components/viewer/PageHighlights.tsx
@@ -1,4 +1,4 @@
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import {
   scopedReferencesAtom,
   scrollToRefAtom,
@@ -8,6 +8,8 @@ import {
   expandGroupForRefAtom,
 } from "../../atoms/references";
 import { collapseAllSignalAtom } from "../../atoms/filters";
+import { highlightsAtom } from "../../atoms/highlights";
+import { focusedEntityIdAtom } from "../../atoms/focusedEntity";
 import { getEntity, getEntityType } from "../../data/entities";
 import { TextSelection } from "../../data/references";
 import { useEffect, useState } from "react";
@@ -60,11 +62,18 @@ export function PageHighlights({ page }: PageHighlightsProps) {
   const setExpandGroupForRef = useSetAtom(expandGroupForRefAtom);
   const setCollapseSignal = useSetAtom(collapseAllSignalAtom);
   const [scrollToHighlight, setScrollToHighlight] = useAtom(scrollToHighlightAtom);
+  const [highlights, setHighlights] = useAtom(highlightsAtom);
+  const focusedEntityId = useAtomValue(focusedEntityIdAtom);
   const [flashId, setFlashId] = useState<string | null>(null);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
   const pageRefs = references.filter(
     (r) => r.sourceSelection?.page === page,
+  );
+
+  // Standalone highlights for this document + page — always painted.
+  const pageHighlights = highlights.filter(
+    (h) => h.entityId === focusedEntityId && h.page === page,
   );
 
   // Clear flash when active ref changes
@@ -81,10 +90,10 @@ export function PageHighlights({ page }: PageHighlightsProps) {
     }
   }, [scrollToHighlight, pageRefs, setScrollToHighlight]);
 
-  // Only show highlights that are active or flashing
+  // Only show reference highlights that are active or flashing
   const visibleRefs = pageRefs.filter((r) => r.id === activeRefId || r.id === flashId);
 
-  if (visibleRefs.length === 0) return null;
+  if (visibleRefs.length === 0 && pageHighlights.length === 0) return null;
 
   const handleHighlightClick = (refId: string) => {
     setActiveDrawerTab("connections");
@@ -95,6 +104,38 @@ export function PageHighlights({ page }: PageHighlightsProps) {
 
   return (
     <>
+      {/* Standalone highlights — always visible, click to remove. Painted from
+          the exact per-line rects captured at selection time. */}
+      {pageHighlights.map((hl) => {
+        const isHovered = hoveredId === hl.id;
+        return hl.rects.map((rect, i) => (
+          <div
+            key={`${hl.id}-${i}`}
+            role={i === 0 ? "button" : undefined}
+            tabIndex={i === 0 ? 0 : undefined}
+            aria-label={i === 0 ? `Remove highlight: ${hl.text.slice(0, 60)}` : undefined}
+            title={i === 0 ? "Remove highlight" : undefined}
+            onClick={() => setHighlights((prev) => prev.filter((h) => h.id !== hl.id))}
+            onKeyDown={i === 0 ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setHighlights((prev) => prev.filter((h) => h.id !== hl.id));
+              }
+            } : undefined}
+            onMouseEnter={() => setHoveredId(hl.id)}
+            onMouseLeave={() => setHoveredId(null)}
+            className="absolute cursor-pointer rounded-[2px] transition-colors duration-150"
+            style={{
+              top: `${rect.top * 100}%`,
+              left: `${rect.left * 100}%`,
+              width: `${rect.width * 100}%`,
+              height: `${rect.height * 100}%`,
+              backgroundColor: hexToRgba(hl.color, isHovered ? 0.42 : 0.3),
+              zIndex: isHovered ? 10 : 4,
+            }}
+          />
+        ));
+      })}
       {visibleRefs.map((ref) => {
         const sel = ref.sourceSelection;
         if (!sel) return null;

--- a/app/src/data/settings.ts
+++ b/app/src/data/settings.ts
@@ -1,0 +1,361 @@
+/** Mock seed for the cloned Settings views. Shapes mirror Uwazi's real
+ *  collections (languages, users, groups) but trimmed to what the prototype
+ *  renders. No backend — these are the initial atom values. */
+import { entityTypes } from "./entities";
+
+export interface SettingsLanguage {
+  key: string;
+  label: string;
+  localizedLabel: string;
+  ltr: boolean;
+  default: boolean;
+  translationsCount: number;
+}
+
+export const seedLanguages: SettingsLanguage[] = [
+  { key: "en", label: "English", localizedLabel: "English", ltr: true, default: true, translationsCount: 100 },
+  { key: "es", label: "Spanish", localizedLabel: "Español", ltr: true, default: false, translationsCount: 100 },
+  { key: "fr", label: "French", localizedLabel: "Français", ltr: true, default: false, translationsCount: 94 },
+  { key: "ar", label: "Arabic", localizedLabel: "العربية", ltr: false, default: false, translationsCount: 81 },
+  { key: "pt", label: "Portuguese", localizedLabel: "Português", ltr: true, default: false, translationsCount: 67 },
+];
+
+export type UserRole = "admin" | "editor" | "collaborator";
+
+export interface SettingsUser {
+  id: string;
+  username: string;
+  email: string;
+  role: UserRole;
+  groups: string[];
+  using2fa: boolean;
+}
+
+export const seedUsers: SettingsUser[] = [
+  { id: "u1", username: "admin", email: "admin@uwazi.io", role: "admin", groups: ["Administrators"], using2fa: true },
+  { id: "u2", username: "mlopez", email: "m.lopez@cejil.org", role: "editor", groups: ["Litigation"], using2fa: true },
+  { id: "u3", username: "jnkemba", email: "j.nkemba@example.org", role: "editor", groups: ["Litigation", "Research"], using2fa: false },
+  { id: "u4", username: "afarah", email: "a.farah@example.org", role: "collaborator", groups: ["Research"], using2fa: false },
+  { id: "u5", username: "tbuergenthal", email: "t.buergenthal@example.org", role: "collaborator", groups: [], using2fa: false },
+];
+
+export interface SettingsGroupRecord {
+  id: string;
+  name: string;
+  memberCount: number;
+}
+
+export const seedGroups: SettingsGroupRecord[] = [
+  { id: "g1", name: "Administrators", memberCount: 1 },
+  { id: "g2", name: "Litigation", memberCount: 2 },
+  { id: "g3", name: "Research", memberCount: 2 },
+];
+
+/** The signed-in account (Account settings page). */
+export const currentAccount = {
+  username: "admin",
+  email: "admin@uwazi.io",
+  role: "admin" as UserRole,
+};
+
+// ── Templates ──────────────────────────────────────────────────────────────
+export interface SettingsTemplate {
+  id: string;
+  name: string;
+  color: string;
+  propertyCount: number;
+  entityCount: number;
+  isDefault: boolean;
+}
+
+export const seedTemplates: SettingsTemplate[] = entityTypes.map((t, i) => ({
+  id: t.id,
+  name: t.name,
+  color: t.color,
+  propertyCount: [8, 12, 6, 10, 5, 7, 9, 4][i] ?? 6,
+  entityCount: [18, 13, 9, 6, 4, 5, 3, 2][i] ?? 1,
+  isDefault: t.id === "court_case",
+}));
+
+export type PropertyType =
+  | "text"
+  | "select"
+  | "relationship"
+  | "date"
+  | "numeric"
+  | "markdown"
+  | "geolocation"
+  | "image";
+
+export interface TemplateProperty {
+  id: string;
+  label: string;
+  type: PropertyType;
+  required: boolean;
+  filterable: boolean;
+}
+
+/** Per-template property lists for the Template editor. Court Case is fleshed
+ *  out; others fall back to a small default set. */
+export const templatePropertiesByTemplate: Record<string, TemplateProperty[]> = {
+  court_case: [
+    { id: "cp1", label: "Case number", type: "text", required: true, filterable: true },
+    { id: "cp2", label: "Date filed", type: "date", required: true, filterable: true },
+    { id: "cp3", label: "Respondent state", type: "relationship", required: true, filterable: true },
+    { id: "cp4", label: "Status", type: "select", required: false, filterable: true },
+    { id: "cp5", label: "Summary", type: "markdown", required: false, filterable: false },
+    { id: "cp6", label: "Location", type: "geolocation", required: false, filterable: false },
+  ],
+  person: [
+    { id: "pp1", label: "Full name", type: "text", required: true, filterable: true },
+    { id: "pp2", label: "Date of birth", type: "date", required: false, filterable: true },
+    { id: "pp3", label: "Nationality", type: "relationship", required: false, filterable: true },
+    { id: "pp4", label: "Photo", type: "image", required: false, filterable: false },
+  ],
+};
+
+export const defaultTemplateProperties: TemplateProperty[] = [
+  { id: "dp1", label: "Title", type: "text", required: true, filterable: true },
+  { id: "dp2", label: "Date", type: "date", required: false, filterable: true },
+  { id: "dp3", label: "Description", type: "markdown", required: false, filterable: false },
+];
+
+export const propertyTypeLabels: Record<PropertyType, string> = {
+  text: "Text",
+  select: "Select",
+  relationship: "Relationship",
+  date: "Date",
+  numeric: "Number",
+  markdown: "Rich text",
+  geolocation: "Geolocation",
+  image: "Image",
+};
+
+// ── Thesauri (dictionaries) ─────────────────────────────────────────────────
+export interface SettingsThesaurus {
+  id: string;
+  name: string;
+  itemCount: number;
+}
+
+export const seedThesauri: SettingsThesaurus[] = [
+  { id: "t1", name: "Violation types", itemCount: 24 },
+  { id: "t2", name: "Legal instruments", itemCount: 16 },
+  { id: "t3", name: "Case status", itemCount: 5 },
+  { id: "t4", name: "Document types", itemCount: 11 },
+  { id: "t5", name: "Regions", itemCount: 8 },
+];
+
+/** Representative items per thesaurus, for the thesaurus detail editor.
+ *  (Prototype sample — not the full `itemCount` set.) */
+export const seedThesaurusItems: Record<string, string[]> = {
+  t1: [
+    "Arbitrary detention",
+    "Enforced disappearance",
+    "Extrajudicial execution",
+    "Torture",
+    "Forced displacement",
+    "Denial of fair trial",
+  ],
+  t2: [
+    "American Convention on Human Rights",
+    "Convention against Torture",
+    "Geneva Conventions",
+    "ICCPR",
+  ],
+  t3: ["Open", "Under review", "Admissible", "Decided", "Archived"],
+  t4: ["Judgment", "Petition", "Amicus brief", "Witness statement", "Press release"],
+  t5: ["Americas", "Andean region", "Central America", "Caribbean", "Southern Cone"],
+};
+
+// ── Relationship types ──────────────────────────────────────────────────────
+export interface SettingsRelationType {
+  id: string;
+  name: string;
+  usageCount: number;
+}
+
+export const seedRelationTypes: SettingsRelationType[] = [
+  { id: "r1", name: "Mentions", usageCount: 142 },
+  { id: "r2", name: "Relates to", usageCount: 87 },
+  { id: "r3", name: "Cites", usageCount: 54 },
+  { id: "r4", name: "Refers to", usageCount: 31 },
+  { id: "r5", name: "Represented by", usageCount: 12 },
+];
+
+// ── Translations ────────────────────────────────────────────────────────────
+export interface SettingsTranslationContext {
+  id: string;
+  name: string;
+  type: "System" | "Template" | "Thesaurus" | "Menu";
+  keyCount: number;
+}
+
+export const seedTranslationContexts: SettingsTranslationContext[] = [
+  { id: "tc0", name: "User Interface", type: "System", keyCount: 412 },
+  { id: "tc1", name: "Court Case", type: "Template", keyCount: 12 },
+  { id: "tc2", name: "Person", type: "Template", keyCount: 8 },
+  { id: "tc3", name: "Violation types", type: "Thesaurus", keyCount: 24 },
+  { id: "tc4", name: "Menu", type: "Menu", keyCount: 6 },
+];
+
+/** A translatable term and its value in each active language (by language key).
+ *  Drives the per-context translation editor (Translations → detail). */
+export interface TranslationKey {
+  key: string;
+  values: Record<string, string>;
+}
+
+export const seedTranslationKeys: Record<string, TranslationKey[]> = {
+  tc0: [
+    { key: "Library", values: { en: "Library", es: "Biblioteca", fr: "Bibliothèque", ar: "المكتبة", pt: "Biblioteca" } },
+    { key: "Search", values: { en: "Search", es: "Buscar", fr: "Rechercher", ar: "بحث", pt: "Pesquisar" } },
+    { key: "Filters", values: { en: "Filters", es: "Filtros", fr: "Filtres", ar: "المرشحات", pt: "Filtros" } },
+    { key: "Upload", values: { en: "Upload", es: "Subir", fr: "Téléverser", ar: "رفع", pt: "Enviar" } },
+    { key: "Save", values: { en: "Save", es: "Guardar", fr: "Enregistrer", ar: "حفظ", pt: "Salvar" } },
+    { key: "Cancel", values: { en: "Cancel", es: "Cancelar", fr: "Annuler", ar: "إلغاء", pt: "Cancelar" } },
+  ],
+  tc1: [
+    { key: "Case number", values: { en: "Case number", es: "Número de caso", fr: "Numéro d'affaire", ar: "رقم القضية", pt: "Número do caso" } },
+    { key: "Date filed", values: { en: "Date filed", es: "Fecha de presentación", fr: "Date de dépôt", ar: "تاريخ التقديم", pt: "Data de registro" } },
+    { key: "Respondent state", values: { en: "Respondent state", es: "Estado demandado", fr: "État défendeur", ar: "الدولة المدعى عليها", pt: "Estado requerido" } },
+    { key: "Status", values: { en: "Status", es: "Estado", fr: "Statut", ar: "الحالة", pt: "Estado" } },
+  ],
+  tc4: [
+    { key: "Library", values: { en: "Library", es: "Biblioteca", fr: "Bibliothèque", ar: "المكتبة", pt: "Biblioteca" } },
+    { key: "About", values: { en: "About", es: "Acerca de", fr: "À propos", ar: "حول", pt: "Sobre" } },
+    { key: "Resources", values: { en: "Resources", es: "Recursos", fr: "Ressources", ar: "موارد", pt: "Recursos" } },
+    { key: "Contact", values: { en: "Contact", es: "Contacto", fr: "Contact", ar: "اتصل", pt: "Contato" } },
+  ],
+};
+
+// ── Pages ───────────────────────────────────────────────────────────────────
+export interface SettingsPage {
+  id: string;
+  title: string;
+  slug: string;
+  published: boolean;
+}
+
+export const seedPages: SettingsPage[] = [
+  { id: "p1", title: "About this collection", slug: "about", published: true },
+  { id: "p2", title: "Methodology", slug: "methodology", published: true },
+  { id: "p3", title: "Partners", slug: "partners", published: false },
+  { id: "p4", title: "Contact", slug: "contact", published: true },
+];
+
+// ── Activity log ────────────────────────────────────────────────────────────
+export type LogMethod = "CREATE" | "UPDATE" | "DELETE" | "MIGRATE";
+
+export interface SettingsLogEntry {
+  id: string;
+  time: string;
+  user: string;
+  method: LogMethod;
+  summary: string;
+}
+
+export const seedActivityLog: SettingsLogEntry[] = [
+  { id: "l1", time: "2026-06-15 18:42", user: "admin", method: "UPDATE", summary: "Updated entity “Velásquez-Rodríguez v. Honduras”" },
+  { id: "l2", time: "2026-06-15 17:10", user: "mlopez", method: "CREATE", summary: "Created relationship type “Represented by”" },
+  { id: "l3", time: "2026-06-15 14:55", user: "mlopez", method: "CREATE", summary: "Created entity “Case 12.250 (Bámaca Velásquez)”" },
+  { id: "l4", time: "2026-06-14 09:30", user: "admin", method: "DELETE", summary: "Deleted user “t.guest@example.org”" },
+  { id: "l5", time: "2026-06-13 22:05", user: "system", method: "MIGRATE", summary: "Ran migration “add-relationship-tiers”" },
+  { id: "l6", time: "2026-06-13 11:48", user: "jnkemba", method: "UPDATE", summary: "Edited thesaurus “Violation types”" },
+];
+
+// ── Menu (navlinks) ─────────────────────────────────────────────────────────
+export interface SettingsMenuLink {
+  id: string;
+  title: string;
+  url: string;
+  type: "link" | "group";
+}
+
+export const seedMenuLinks: SettingsMenuLink[] = [
+  { id: "m1", title: "Library", url: "/library", type: "link" },
+  { id: "m2", title: "About", url: "/page/about", type: "link" },
+  { id: "m3", title: "Resources", url: "", type: "group" },
+  { id: "m4", title: "Methodology", url: "/page/methodology", type: "link" },
+  { id: "m5", title: "Contact", url: "/page/contact", type: "link" },
+];
+
+// ── Filters configuration ───────────────────────────────────────────────────
+// Which templates surface as library filters (reuses the template list).
+export interface SettingsFilterConfig {
+  templateId: string;
+  name: string;
+  color: string;
+  active: boolean;
+}
+
+export const seedFilterConfig: SettingsFilterConfig[] = seedTemplates.map((t) => ({
+  templateId: t.id,
+  name: t.name,
+  color: t.color,
+  active: !["document", "organization"].includes(t.id),
+}));
+
+// ── Metadata extraction (IX) ────────────────────────────────────────────────
+export type ExtractorStatus = "ready" | "training" | "processing" | "error";
+
+export interface SettingsExtractor {
+  id: string;
+  property: string;
+  template: string;
+  status: ExtractorStatus;
+  documents: number;
+  accuracy: number | null;
+}
+
+export const seedExtractors: SettingsExtractor[] = [
+  { id: "x1", property: "Date filed", template: "Court Case", status: "ready", documents: 142, accuracy: 94 },
+  { id: "x2", property: "Respondent state", template: "Court Case", status: "ready", documents: 142, accuracy: 88 },
+  { id: "x3", property: "Court", template: "Judgment", status: "training", documents: 56, accuracy: null },
+  { id: "x4", property: "Date of birth", template: "Person", status: "processing", documents: 38, accuracy: 71 },
+  { id: "x5", property: "Article", template: "Right", status: "error", documents: 12, accuracy: null },
+];
+
+// ── Paragraph extraction ────────────────────────────────────────────────────
+export interface SettingsParagraphJob {
+  id: string;
+  template: string;
+  status: ExtractorStatus;
+  paragraphs: number;
+}
+
+export const seedParagraphJobs: SettingsParagraphJob[] = [
+  { id: "pe1", template: "Judgment", status: "ready", paragraphs: 1840 },
+  { id: "pe2", template: "Court Case", status: "processing", paragraphs: 612 },
+  { id: "pe3", template: "Document", status: "ready", paragraphs: 327 },
+];
+
+// ── Preserve ────────────────────────────────────────────────────────────────
+export interface SettingsPreserveToken {
+  id: string;
+  name: string;
+  token: string;
+  capturedCount: number;
+  lastRun: string;
+}
+
+export const seedPreserveTokens: SettingsPreserveToken[] = [
+  { id: "pr1", name: "Court press releases", token: "pk_live_a1b2…f9", capturedCount: 214, lastRun: "2026-06-15 06:00" },
+  { id: "pr2", name: "NGO bulletins", token: "pk_live_c3d4…2a", capturedCount: 87, lastRun: "2026-06-14 06:00" },
+];
+
+// ── Uploads (custom uploads) ────────────────────────────────────────────────
+export interface SettingsUpload {
+  id: string;
+  name: string;
+  type: "image" | "pdf" | "font" | "other";
+  size: string;
+  url: string;
+}
+
+export const seedUploads: SettingsUpload[] = [
+  { id: "up1", name: "logo-iachr.svg", type: "image", size: "12 KB", url: "/uploads/logo-iachr.svg" },
+  { id: "up2", name: "cover-banner.jpg", type: "image", size: "248 KB", url: "/uploads/cover-banner.jpg" },
+  { id: "up3", name: "style-guide.pdf", type: "pdf", size: "1.4 MB", url: "/uploads/style-guide.pdf" },
+  { id: "up4", name: "Inter-brand.woff2", type: "font", size: "64 KB", url: "/uploads/Inter-brand.woff2" },
+];

--- a/app/src/views/ComponentCatalog.tsx
+++ b/app/src/views/ComponentCatalog.tsx
@@ -24,6 +24,12 @@ import { AlertBanner } from "../components/shared/AlertBanner";
 import { Breadcrumb } from "../components/layout/Breadcrumb";
 import { ToolsSidebar } from "../components/layout/ToolsSidebar";
 
+// Settings primitives (static demos)
+import { Button as SettingsButton } from "../components/settings/Button";
+import { Field, TextInput } from "../components/settings/Field";
+import { RowActions } from "../components/settings/RowActions";
+import { StatusPill } from "../components/settings/StatusPill";
+
 // Icons
 import { ArrowLeft, FileText, Pencil, Download, Trash2, Share2, Plus } from "lucide-react";
 
@@ -67,6 +73,8 @@ import {
   IsolatedRelationshipFieldCard,
   IsolatedInheritedValueChip,
   IsolatedRelationshipFieldEditor,
+  IsolatedRadioGroup,
+  IsolatedDataTable,
 } from "./catalog/demos";
 
 import { sidebarGroups, allItemIds } from "./catalog/sidebarGroups";
@@ -1411,6 +1419,120 @@ export function ComponentCatalog({ onReturn }: Props) {
                 </CatalogEntry>
               </div>
 
+            </div>
+          </section>
+
+          {/* ==================== SETTINGS ==================== */}
+          <section>
+            <h2 className="text-lg font-bold text-ink mb-6">Settings</h2>
+            <div className="flex flex-col gap-6">
+              <div id="set-data-table" ref={reg("set-data-table")}>
+                <CatalogEntry
+                  name="DataTable"
+                  description="The canonical data table (entity-view Files style), generic via a declarative column API. Backs FileTable and every Settings list."
+                  code={`<DataTable
+  data={rows}
+  getRowId={(r) => r.id}
+  onRowClick={(r) => …}
+  isRowSelected={(r) => r.id === selected}
+  footer={<span>{rows.length} rows</span>}
+  columns={[
+    { id: "name", header: "Template", cell: (r) => r.name },
+    { id: "count", header: "Entities", width: "6rem", align: "right", cell: (r) => r.count },
+  ]}
+/>`}
+                >
+                  <div className="w-full max-w-md">
+                    <IsolatedDataTable />
+                  </div>
+                </CatalogEntry>
+              </div>
+
+              <div id="set-radio-group" ref={reg("set-radio-group")}>
+                <CatalogEntry
+                  name="RadioGroup"
+                  description="Single-choice control (native radios, label + hint). For picking one setting value — not navigation (that's tabs)."
+                  code={`<RadioGroup
+  name="default-view"
+  value={value}
+  onChange={setValue}
+  options={[
+    { id: "cards", label: "Cards", hint: "Visual entity cards" },
+    { id: "table", label: "Table", hint: "Dense rows" },
+  ]}
+/>`}
+                >
+                  <div className="w-full max-w-md">
+                    <IsolatedRadioGroup />
+                  </div>
+                </CatalogEntry>
+              </div>
+
+              <div id="set-button" ref={reg("set-button")}>
+                <CatalogEntry
+                  name="Button"
+                  description="Settings-scoped action button. Warm fill is canonical; seal for danger only."
+                  code={`<Button variant="primary" size="sm">Save</Button>
+<Button variant="secondary" size="sm">Translate</Button>
+<Button variant="ghost" size="sm">Cancel</Button>
+<Button variant="danger" size="sm">Delete</Button>`}
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <SettingsButton variant="primary" size="sm">Save</SettingsButton>
+                    <SettingsButton variant="secondary" size="sm">Translate</SettingsButton>
+                    <SettingsButton variant="ghost" size="sm">Cancel</SettingsButton>
+                    <SettingsButton variant="danger" size="sm">Delete</SettingsButton>
+                    <SettingsButton variant="primary" size="sm" disabled>Disabled</SettingsButton>
+                  </div>
+                </CatalogEntry>
+              </div>
+
+              <div id="set-field" ref={reg("set-field")}>
+                <CatalogEntry
+                  name="Field"
+                  description="Labelled form field wrapper (label + hint/error) with the warm TextInput."
+                  code={`<Field label="Email" hint="Used to sign in.">
+  <TextInput type="email" defaultValue="admin@uwazi.io" />
+</Field>`}
+                >
+                  <div className="w-full max-w-sm flex flex-col gap-3">
+                    <Field label="Email" hint="Used to sign in.">
+                      <TextInput type="email" defaultValue="admin@uwazi.io" />
+                    </Field>
+                    <Field label="Password" error="Passwords don't match">
+                      <TextInput type="password" defaultValue="••••••" />
+                    </Field>
+                  </div>
+                </CatalogEntry>
+              </div>
+
+              <div id="set-status-pill" ref={reg("set-status-pill")}>
+                <CatalogEntry
+                  name="StatusPill"
+                  description="Status badge for extraction / processing jobs, on semantic tints."
+                  code={`<StatusPill status="ready" /> // ready | training | processing | error`}
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill status="ready" />
+                    <StatusPill status="training" />
+                    <StatusPill status="processing" />
+                    <StatusPill status="error" />
+                  </div>
+                </CatalogEntry>
+              </div>
+
+              <div id="set-row-actions" ref={reg("set-row-actions")}>
+                <CatalogEntry
+                  name="RowActions"
+                  description="Edit + delete icon pair for a table row. Stops row-click propagation."
+                  code={`<RowActions label="Court Case" onEdit={() => …} onDelete={() => …} />`}
+                >
+                  <div className="w-full max-w-xs flex items-center justify-between bg-paper border border-border-soft rounded-md px-3 py-2">
+                    <span className="text-sm text-ink">Court Case</span>
+                    <RowActions label="Court Case" onEdit={() => {}} onDelete={() => {}} />
+                  </div>
+                </CatalogEntry>
+              </div>
             </div>
           </section>
         </div>

--- a/app/src/views/SettingsView.tsx
+++ b/app/src/views/SettingsView.tsx
@@ -1,0 +1,93 @@
+import { useAtomValue } from "jotai";
+import { settingsSectionAtom, settingsMobileDrilledAtom } from "../atoms/settings";
+import { breakpointAtom } from "../atoms/viewport";
+import type { AppView } from "../atoms/navigation";
+import { SettingsNav } from "../components/settings/SettingsNav";
+import { AccountPage } from "../components/settings/pages/AccountPage";
+import { LanguagesPage } from "../components/settings/pages/LanguagesPage";
+import { UsersPage } from "../components/settings/pages/UsersPage";
+import { CollectionPage } from "../components/settings/pages/CollectionPage";
+import { TemplatesPage } from "../components/settings/pages/TemplatesPage";
+import { ThesauriPage } from "../components/settings/pages/ThesauriPage";
+import { RelationTypesPage } from "../components/settings/pages/RelationTypesPage";
+import { TranslationsPage } from "../components/settings/pages/TranslationsPage";
+import { PagesPage } from "../components/settings/pages/PagesPage";
+import { ActivityLogPage } from "../components/settings/pages/ActivityLogPage";
+import { DashboardPage } from "../components/settings/pages/DashboardPage";
+import { MenuPage } from "../components/settings/pages/MenuPage";
+import { FiltersPage } from "../components/settings/pages/FiltersPage";
+import { MetadataExtractionPage } from "../components/settings/pages/MetadataExtractionPage";
+import { ParagraphExtractionPage } from "../components/settings/pages/ParagraphExtractionPage";
+import { PreservePage } from "../components/settings/pages/PreservePage";
+import { UploadsPage } from "../components/settings/pages/UploadsPage";
+import { CustomisationPage } from "../components/settings/pages/CustomisationPage";
+import { PlaceholderPage } from "../components/settings/pages/PlaceholderPage";
+
+/** Settings takeover — a fixed-width rail + content outlet, mirroring Uwazi's
+ *  V2 Settings shell. Cloned pages render natively; the rest fall back to a
+ *  placeholder so the whole IA is navigable. */
+export function SettingsView({ onNavigate }: { onNavigate?: (view: AppView) => void }) {
+  const section = useAtomValue(settingsSectionAtom);
+  const drilled = useAtomValue(settingsMobileDrilledAtom);
+  const isMobile = useAtomValue(breakpointAtom) === "mobile";
+
+  const page = (() => {
+    switch (section) {
+      case "account":
+        return <AccountPage />;
+      case "languages":
+        return <LanguagesPage />;
+      case "users":
+        return <UsersPage />;
+      case "collection":
+        return <CollectionPage />;
+      case "templates":
+        return <TemplatesPage />;
+      case "thesauri":
+        return <ThesauriPage />;
+      case "relationship-types":
+        return <RelationTypesPage />;
+      case "translations":
+        return <TranslationsPage />;
+      case "pages":
+        return <PagesPage />;
+      case "activitylog":
+        return <ActivityLogPage />;
+      case "dashboard":
+        return <DashboardPage />;
+      case "menu":
+        return <MenuPage />;
+      case "filters":
+        return <FiltersPage />;
+      case "metadata-extraction":
+        return <MetadataExtractionPage />;
+      case "paragraph-extraction":
+        return <ParagraphExtractionPage />;
+      case "preserve":
+        return <PreservePage />;
+      case "uploads":
+        return <UploadsPage />;
+      case "customisation":
+        return <CustomisationPage />;
+      default:
+        return <PlaceholderPage section={section} />;
+    }
+  })();
+
+  // Mobile drills in: rail until a section is picked, then the section
+  // full-width (its header carries the back chevron). Desktop shows both.
+  if (isMobile) {
+    return (
+      <div className="h-full min-h-0">
+        {drilled ? page : <SettingsNav onNavigate={onNavigate} />}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0">
+      <SettingsNav onNavigate={onNavigate} />
+      <div className="flex-1 min-w-0 min-h-0">{page}</div>
+    </div>
+  );
+}

--- a/app/src/views/catalog/demos.tsx
+++ b/app/src/views/catalog/demos.tsx
@@ -12,6 +12,8 @@ import { FiltersRow, ViewModeControls, CollapseControls } from "../../components
 import { FiltersButton } from "../../components/shared/FiltersButton";
 import { FiltersDrawer } from "../../components/shared/FiltersDrawer";
 import { FacetSection } from "../../components/shared/FacetSection";
+import { RadioGroup } from "../../components/shared/RadioGroup";
+import { DataTable } from "../../components/shared/DataTable";
 import { FadeTruncate } from "../../components/shared/FadeTruncate";
 import { ListInfoRow } from "../../components/shared/ListInfoRow";
 import { Checkbox } from "../../components/shared/Checkbox";
@@ -850,5 +852,44 @@ export function IsolatedDirectionGlyph() {
         <span className="text-[10px] text-ink-muted">md</span>
       </div>
     </div>
+  );
+}
+
+export function IsolatedRadioGroup() {
+  const [value, setValue] = useState("cards");
+  return (
+    <RadioGroup
+      name="catalog-radio"
+      ariaLabel="Default view"
+      value={value}
+      onChange={setValue}
+      options={[
+        { id: "cards", label: "Cards", hint: "Visual entity cards" },
+        { id: "table", label: "Table", hint: "Dense rows" },
+        { id: "map", label: "Map", hint: "Geographic" },
+      ]}
+    />
+  );
+}
+
+export function IsolatedDataTable() {
+  const [selected, setSelected] = useState<string | null>("r2");
+  const rows = [
+    { id: "r1", name: "Court Case", count: 18 },
+    { id: "r2", name: "Person", count: 13 },
+    { id: "r3", name: "Country", count: 9 },
+  ];
+  return (
+    <DataTable
+      data={rows}
+      getRowId={(r) => r.id}
+      onRowClick={(r) => setSelected(r.id)}
+      isRowSelected={(r) => r.id === selected}
+      footer={<span>{rows.length} rows</span>}
+      columns={[
+        { id: "name", header: "Template", cell: (r) => <span className="text-xs font-medium text-ink">{r.name}</span> },
+        { id: "count", header: "Entities", width: "6rem", align: "right", cell: (r) => <span className="text-xs text-ink-tertiary tabular-nums">{r.count}</span> },
+      ]}
+    />
   );
 }

--- a/app/src/views/catalog/sidebarGroups.ts
+++ b/app/src/views/catalog/sidebarGroups.ts
@@ -130,6 +130,17 @@ export const sidebarGroups: SidebarGroup[] = [
       { id: "sh-uwazi-loader", label: "UwaziLoader" },
     ],
   },
+  {
+    label: "Settings",
+    items: [
+      { id: "set-data-table", label: "DataTable" },
+      { id: "set-radio-group", label: "RadioGroup" },
+      { id: "set-button", label: "Button" },
+      { id: "set-field", label: "Field" },
+      { id: "set-status-pill", label: "StatusPill" },
+      { id: "set-row-actions", label: "RowActions" },
+    ],
+  },
 ];
 
 export const allItemIds = sidebarGroups.flatMap((g) =>


### PR DESCRIPTION
Builds out the Settings section on top of the merged metadata-relationship-tiers base.

## What's in here
- **Shared `DataTable`** — extracts the entity-view Files table style into one generic, column-driven component; `FileTable` and every Settings list now render through it.
- **Settings V2 clone + nested detail editors** — list→detail child views for Templates, Users, Groups, Thesauri, Relationship types, Pages, Menu, Metadata extractors, Preserve, Translations (key × language grid), Paragraph extraction.
- **Primitives** — `RadioGroup` (default-library-view), navigation tabs for Users/Groups + CSS/JS, `SegmentedControl` inline-flex fix.
- **Filters** — grouped/orderable config rendered on the shared `DataTable`.
- **Save bar + breadcrumbs** — right-aligned Cancel · Save, green Save enabled only when the view is dirty, clickable breadcrumbs + back arrow in nested views.
- **Reload persistence** — `appView` + settings section survive a browser reload.
- **Catalog** — registers the new shared/settings components.

`tsc --noEmit` green throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)