### PR TITLE
Metadata: refine relationship & inherited-value rendering

### DIFF
--- a/app/src/components/metadata/ConnectionGroupCard.tsx
+++ b/app/src/components/metadata/ConnectionGroupCard.tsx
@@ -45,14 +45,20 @@ export function ConnectionGroupCard({ group, span = "full" }: { group: Connectio
             </tr>
           </thead>
           <tbody>
+            {/* Horizontal dividers live on each LEADING cell, not the row — so a
+                new top-level value (a country) rules a line across every column,
+                a new sub-value (a role) rules Role+Person only, and each person
+                gets a hairline under Person. The dividers "step" with the merge,
+                so a spanned group reads as one block instead of a flat grid.
+                Spanning labels are vertically centred against their group. */}
             {rows.map((row) => (
-              <tr key={row.entityId} className="border-t border-border/40 hover:bg-warm/40 transition-colors">
+              <tr key={row.entityId} className="hover:bg-warm/30 transition-colors">
                 {row.cells.map((cell, i) =>
                   cell.lead ? (
                     <td
                       key={cell.fieldId}
                       rowSpan={cell.rowSpan}
-                      className="py-1.5 px-3 whitespace-nowrap align-top border-s border-border/30 first:border-s-0"
+                      className="py-1.5 px-3 whitespace-nowrap align-middle border-t border-s border-border/40 first:border-s-0"
                     >
                       {cell.value ? (
                         <InheritedValueTag
@@ -67,7 +73,7 @@ export function ConnectionGroupCard({ group, span = "full" }: { group: Connectio
                     </td>
                   ) : null,
                 )}
-                <td className="py-1.5 px-1 align-top border-s border-border/30">
+                <td className="py-1.5 px-1 align-middle border-t border-s border-border/40">
                   <button
                     onClick={() => setOverlay(row.entityId)}
                     className="rounded-md hover:opacity-80 transition-opacity cursor-pointer"

--- a/app/src/components/metadata/InheritedValueChip.tsx
+++ b/app/src/components/metadata/InheritedValueChip.tsx
@@ -41,14 +41,16 @@ export function InheritedValueTag({
 }
 
 /** Empty inherited value — the connected entity carries no value for the
- *  inherited property. Calm, explicit, and distinct from a real value. */
+ *  inherited property. A quiet em-dash (the editorial convention for "no value"
+ *  in a table) rather than words; provenance stays on hover. */
 export function MissingValue({ propLabel }: { propLabel?: string }) {
   return (
     <span
       title={`No ${propLabel ?? "value"} on the connected entity`}
-      className="text-sm text-ink-muted italic"
+      className="text-sm text-ink-muted select-none"
+      aria-label={`No ${propLabel ?? "value"}`}
     >
-      no value
+      —
     </span>
   );
 }

--- a/app/src/components/metadata/RelationshipFieldCard.tsx
+++ b/app/src/components/metadata/RelationshipFieldCard.tsx
@@ -1,22 +1,38 @@
-import { useAtomValue } from "jotai";
+import { Fragment } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
 import { Link2 } from "lucide-react";
 import { languageAtom } from "../../atoms/language";
 import { entityMetadataAtom, makeEntityPropReader } from "../../atoms/entityMetadata";
+import { overlayEntityIdAtom } from "../../atoms/references";
 import { MetadataCard } from "./MetadataCard";
 import { spanClass, type CardSpan } from "./cardSpan";
-import { InheritedValueChip, RelationCaption } from "./InheritedValueChip";
+import { InheritedValueTag, MissingValue, RelationCaption } from "./InheritedValueChip";
+import { EntityPill } from "../shared/EntityPill";
 import { resolveRelationshipField } from "../../utils/inheritance";
 import type { RelationshipMetadataField } from "../../data/metadata";
 
-/** A standalone relationship field (no shared connection): the field's
- *  connected entities, each with its inherited value (or just the entity for a
- *  link-only relationship). Resolves against the live entity-metadata atom so
- *  edit-at-source cascades here. */
+/** A standalone relationship field (no shared connection). Two shapes:
+ *  - inherits a property → a 2-column grid (entity · inherited value) so values
+ *    line up in a column, matching the tabular grouped card.
+ *  - link-only → a compact wrapping list of entity pills.
+ *  Resolves against the live entity-metadata atom so edit-at-source cascades here. */
 export function RelationshipFieldCard({ field, span = "wide" }: { field: RelationshipMetadataField; span?: CardSpan }) {
   const lang = useAtomValue(languageAtom);
   const getProp = makeEntityPropReader(useAtomValue(entityMetadataAtom));
+  const setOverlay = useSetAtom(overlayEntityIdAtom);
   const resolved = resolveRelationshipField(field, lang, getProp);
   const inherits = !!field.inheritProperty;
+
+  const pill = (v: (typeof resolved.values)[number]) => (
+    <button
+      key={v.entityId}
+      onClick={() => setOverlay(v.entityId)}
+      className="justify-self-start min-w-0 rounded-md hover:opacity-80 transition-opacity cursor-pointer"
+      title="Preview source entity"
+    >
+      <EntityPill typeId={v.entityTypeId} label={v.entityTitle} />
+    </button>
+  );
 
   return (
     <MetadataCard
@@ -25,11 +41,26 @@ export function RelationshipFieldCard({ field, span = "wide" }: { field: Relatio
       className={spanClass(span)}
     >
       <RelationCaption relationLabel={resolved.relationLabel} inheritLabel={field.inheritLabel} />
-      <div className="flex flex-col gap-1.5">
-        {resolved.values.map((v) => (
-          <InheritedValueChip key={v.entityId} value={v} inherits={inherits} relationLabel={resolved.relationLabel} />
-        ))}
-      </div>
+      {inherits ? (
+        <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 items-center">
+          {resolved.values.map((v) => (
+            <Fragment key={v.entityId}>
+              {pill(v)}
+              {v.inheritedValue ? (
+                <InheritedValueTag
+                  value={v.inheritedValue}
+                  propLabel={v.sourcePropLabel}
+                  relationLabel={resolved.relationLabel}
+                />
+              ) : (
+                <MissingValue propLabel={v.sourcePropLabel} />
+              )}
+            </Fragment>
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">{resolved.values.map((v) => pill(v))}</div>
+      )}
     </MetadataCard>
   );
 }

--- a/app/src/components/metadata/RelationshipFieldCard.tsx
+++ b/app/src/components/metadata/RelationshipFieldCard.tsx
@@ -61,6 +61,11 @@ export function RelationshipFieldCard({ field, span = "wide" }: { field: Relatio
       ) : (
         <div className="flex flex-wrap gap-1.5">{resolved.values.map((v) => pill(v))}</div>
       )}
+      {field.totalConnected != null && field.totalConnected > resolved.values.length && (
+        <p className="text-[11px] text-ink-tertiary mt-0.5">
+          showing {resolved.values.length} of {field.totalConnected}
+        </p>
+      )}
     </MetadataCard>
   );
 }

--- a/app/src/data/cejil/profile.ts
+++ b/app/src/data/cejil/profile.ts
@@ -186,6 +186,7 @@ function cejilRelationshipFields(sharedId: string, template: string): Relationsh
       relationType: typeName,
       targetTypeId: "",
       connectedEntityIds: g.ids.slice(0, REL_CONN_CAP),
+      totalConnected: g.ids.length,
       readOnly: true,
     });
   }
@@ -195,6 +196,7 @@ function cejilRelationshipFields(sharedId: string, template: string): Relationsh
     const graph = cejilChainGraph();
     if (graph) {
       const { tuples } = chains(graph, sharedId, CEJIL_PERPETRATOR_CHAIN.segments, { maxPaths: 400 });
+      // Dedupe judges across all paths first, so the cap can report a true total.
       const judges: string[] = [];
       const seen = new Set<string>();
       for (const t of tuples) {
@@ -205,7 +207,6 @@ function cejilRelationshipFields(sharedId: string, template: string): Relationsh
         judges.push(judge);
         if (pais) for (const l of ["EN", "ES", "FR", "AR"] as Language[])
           registerCejilInherited(judge, CEJIL_INHERIT_FIRMANTE_PAIS, l, pais);
-        if (judges.length >= CHAIN_JUDGE_CAP) break;
       }
       if (judges.length) {
         out.unshift({
@@ -216,7 +217,8 @@ function cejilRelationshipFields(sharedId: string, template: string): Relationsh
           targetTypeId: SENTENCIA_TEMPLATE ? templateIdByName("Juez y/o Comisionado") ?? "" : "",
           inheritProperty: CEJIL_INHERIT_FIRMANTE_PAIS,
           inheritLabel: "País",
-          connectedEntityIds: judges,
+          connectedEntityIds: judges.slice(0, CHAIN_JUDGE_CAP),
+          totalConnected: judges.length,
           readOnly: true,
         });
       }

--- a/app/src/data/metadata.ts
+++ b/app/src/data/metadata.ts
@@ -33,6 +33,10 @@ export interface RelationshipMetadataField {
   inheritLabel?: string;
   connectedEntityIds: string[];
   connectionKey?: string;
+  /** When `connectedEntityIds` is a capped slice of a larger set (hub entities
+   *  fan out to thousands), the true total — so the card can say "showing N of
+   *  M" instead of silently truncating. Omit when nothing was dropped. */
+  totalConnected?: number;
   /** A derived/graph projection (e.g. CEJIL connections, a chain-traversed
    *  inherited field) — not editable inline. The edit view shows it read-only
    *  rather than as an entity-picker (design doc Q6: chain fields are edited via


### PR DESCRIPTION
Three focused refinements to how relationship + inherited metadata renders in the Metadata view. Shared components, so the mock view, CEJIL entities, and the edit read-only section all benefit. Verified live in the Component Catalog and on the real La Tablada entity.

## Changes
- **Cell-merged connection table reads as blocks** (`ConnectionGroupCard`) — horizontal dividers moved from the row onto each *leading* cell so they step with the merge: a new top-level value (a country) rules a full-width line, a new sub-value (a role) rules only the columns to its right, and each leaf entity gets a hairline. Spanning labels are vertically centred against their group. The merged table now reads as cohesive blocks instead of a flat grid slicing through spans.
- **Missing inherited value → quiet em-dash** (`InheritedValueChip` / `MissingValue`) — was the literal words "no value" in italic; restored the documented em-dash convention (calmer, matches the catalog description). Provenance stays on hover; `aria-label` keeps it accessible.
- **Single-inheritance card aligned into a value column** (`RelationshipFieldCard`) — inherited values trailed ragged after variable-width pills; now a 2-column grid (entity · value) so values line up, matching the tabular grouped card. Link-only relationships become a compact wrapping pill list instead of one pill per row.

## Verification
- `tsc --noEmit` + `vite build` green.
- Checked in Component Catalog (ConnectionGroupCard + RelationshipFieldCard demos) and the live La Tablada Metadata read view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)