### PR TITLE
CEJIL: document inheritance, drawer sync, placeholder PDF, card fit

### DIFF
--- a/app/public/cejil-docs/sample-document.pdf
+++ b/app/public/cejil-docs/sample-document.pdf
@@ -1,0 +1,35 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 286 >>
+stream
+BT /F1 24 Tf 90 660 Td (Sample document) Tj ET
+BT /F1 12 Tf 90 610 Td (This is a placeholder used in the prototype.) Tj ET
+BT /F1 12 Tf 90 592 Td (The original document is not bundled in this sample.) Tj ET
+BT /F1 10 Tf 90 120 Td (CEJIL / SUMMA prototype  -  sample-document.pdf) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000577 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+647
+%%EOF

--- a/app/src/components/library/EntityCard.tsx
+++ b/app/src/components/library/EntityCard.tsx
@@ -98,7 +98,7 @@ export const EntityCard = memo(function EntityCard({
       tabIndex={0}
       onClick={() => onSelect(entity.id)}
       onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onSelect(entity.id)}
-      className={`${base} ${surface} p-3 flex flex-col gap-2.5 h-full`}
+      className={`${base} ${surface} p-3 flex flex-col gap-2.5`}
     >
       {showPreview && entity.preview && (
         <EntityThumbnail

--- a/app/src/components/library/EntityDrawerPreview.tsx
+++ b/app/src/components/library/EntityDrawerPreview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { X, ArrowRight } from "lucide-react";
-import { languageAtom } from "../../atoms/language";
+import { languageAtom, type Language } from "../../atoms/language";
 import { referencesAtom } from "../../atoms/references";
 import { librarySelectedEntityIdAtom } from "../../atoms/library";
 import { openEntityAtom, focusEntityForPreviewAtom } from "../../atoms/focusedEntity";
@@ -14,6 +14,7 @@ import { MainTabs } from "../layout/MainTabs";
 import { DocumentViewer } from "../viewer/DocumentViewer";
 import { RelationshipsDrawerSection } from "../relationships/RelationshipsDrawerSection";
 import { DrawerFilesBody } from "../files/DrawerFilesBody";
+import { RelationshipCards } from "../metadata/RelationshipCards";
 
 /** The right-drawer entity preview. Selecting a library entity focuses it (see
  *  {@link focusEntityForPreviewAtom}) and renders the same main-tab navigation
@@ -124,15 +125,19 @@ export function EntityDrawerPreview({ entityId }: { entityId: string }) {
   );
 }
 
-/** Compact scalar-metadata body for the drawer's Metadata tab, read from the
- *  previewed entity's own profile (not the e3-hardcoded MetadataDrawerContent). */
+/** Compact metadata body for the drawer's Metadata tab, read from the previewed
+ *  entity's own profile (not the e3-hardcoded MetadataDrawerContent). Scalar
+ *  fields first, then the shared RelationshipCards so relationship/inherited
+ *  properties match the main Metadata view. */
 function MetadataSummary({ language, entityId }: { language: string; entityId: string }) {
   const profile = getEntityProfile(entityId);
-  const fields = (profile.metadata[language as keyof typeof profile.metadata] ?? []).filter(
+  const lang = language as Language;
+  const fields = (profile.metadata[lang] ?? []).filter(
     (f): f is MetadataField => f.type !== "relationship" && !!(f as MetadataField).value,
   );
+  const hasRel = (profile.metadata[lang] ?? []).some((f) => f.type === "relationship");
 
-  if (fields.length === 0) {
+  if (fields.length === 0 && !hasRel) {
     return (
       <div className="h-full flex items-center justify-center px-6 text-center">
         <p className="text-xs text-ink-muted">No metadata for this entity yet.</p>
@@ -151,6 +156,7 @@ function MetadataSummary({ language, entityId }: { language: string; entityId: s
             <p className="text-sm text-ink leading-snug">{f.value}</p>
           </div>
         ))}
+        <RelationshipCards profile={profile} language={lang} span="full" />
       </div>
     </div>
   );

--- a/app/src/components/metadata/MetadataCard.tsx
+++ b/app/src/components/metadata/MetadataCard.tsx
@@ -9,8 +9,8 @@ interface MetadataCardProps {
 
 export function MetadataCard({ title, icon, children, className = "" }: MetadataCardProps) {
   return (
-    <div className={`bg-paper border border-border/40 rounded-md overflow-hidden h-full ${className}`}>
-      <div className="flex flex-col gap-2 px-4 py-3 h-full">
+    <div className={`bg-paper border border-border/40 rounded-md overflow-hidden ${className}`}>
+      <div className="flex flex-col gap-2 px-4 py-3">
         <div className="flex items-center gap-1.5">
           {icon}
           <h4 className="text-sm font-bold text-ink leading-tight">{title}</h4>

--- a/app/src/components/metadata/RelationshipCards.tsx
+++ b/app/src/components/metadata/RelationshipCards.tsx
@@ -1,0 +1,50 @@
+import { useAtomValue } from "jotai";
+import type { Language } from "../../atoms/language";
+import { entityMetadataAtom, makeEntityPropReader } from "../../atoms/entityMetadata";
+import type { EntityProfile } from "../../data/entityProfiles";
+import type { RelationshipMetadataField } from "../../data/metadata";
+import { groupConnections } from "../../utils/inheritance";
+import { ConnectionGroupCard } from "./ConnectionGroupCard";
+import { RelationshipFieldCard } from "./RelationshipFieldCard";
+import { spanClass, type CardSpan } from "./cardSpan";
+
+/** The "Relationships" section of an entity's metadata: shared connections
+ *  (multi-inheritance) as grouped tables + standalone relationship fields as
+ *  single cards. Extracted so the main Metadata read view AND the drawers render
+ *  the same relationship/inherited properties from the same source — they can't
+ *  drift apart. Returns null when the entity has no relationship fields.
+ *
+ *  `span` sets the single-field card width: "wide" for the main 3-col grid,
+ *  "full" for a single-column drawer. */
+export function RelationshipCards({
+  profile,
+  language,
+  span = "wide",
+}: {
+  profile: EntityProfile;
+  language: Language;
+  span?: CardSpan;
+}) {
+  const getProp = makeEntityPropReader(useAtomValue(entityMetadataAtom));
+  const relFields = (profile.metadata[language] ?? []).filter(
+    (f): f is RelationshipMetadataField => f.type === "relationship",
+  );
+  const { groups, singles } = groupConnections(relFields, language, getProp);
+  if (groups.length === 0 && singles.length === 0) return null;
+
+  return (
+    <>
+      <div className={`${spanClass("full")} mt-2 flex items-center`}>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-ink-tertiary">
+          Relationships
+        </h3>
+      </div>
+      {groups.map((group) => (
+        <ConnectionGroupCard key={group.connectionKey} group={group} />
+      ))}
+      {singles.map((field) => (
+        <RelationshipFieldCard key={field.id} field={field} span={span} />
+      ))}
+    </>
+  );
+}

--- a/app/src/components/relationships/MetadataDrawerContent.tsx
+++ b/app/src/components/relationships/MetadataDrawerContent.tsx
@@ -2,11 +2,14 @@ import { useMemo, useState } from "react";
 import { useAtomValue } from "jotai";
 import { ChevronDown, ChevronRight, ExternalLink, FileText, Music, Video, Image, Link2 } from "lucide-react";
 import { languageAtom } from "../../atoms/language";
+import { focusedEntityIdAtom } from "../../atoms/focusedEntity";
+import { getEntityProfile } from "../../data/entityProfiles";
 import { documentsByLanguage } from "../../data/document";
 import { metadataFieldsByLanguage, pdfMetadataByLanguage, type MetadataField } from "../../data/metadata";
 import { FileEntry } from "../../data/files";
 import { filesAtom, documentGroupsAtom } from "../../atoms/files";
 import { EntityPill } from "../shared/EntityPill";
+import { RelationshipCards } from "../metadata/RelationshipCards";
 
 const fileTypeIcons: Record<FileEntry["type"], typeof FileText> = {
   pdf: FileText,
@@ -19,6 +22,7 @@ const fileTypeIcons: Record<FileEntry["type"], typeof FileText> = {
 
 export function MetadataDrawerContent() {
   const language = useAtomValue(languageAtom);
+  const profile = getEntityProfile(useAtomValue(focusedEntityIdAtom));
   const doc = documentsByLanguage[language];
   // Condensed scalar summary — relationship/inherited fields live in the main
   // Metadata view, not this drawer.
@@ -104,6 +108,10 @@ export function MetadataDrawerContent() {
           )}
         </div>
       ))}
+
+      {/* Relationship / inherited properties — shared with the main Metadata
+          view so the drawer shows the same connections + inherited values. */}
+      <RelationshipCards profile={profile} language={language} span="full" />
 
       {/* Supporting Files — synced with the Files view */}
       {supportingFiles.length > 0 && (

--- a/app/src/components/viewer/DocumentViewer.tsx
+++ b/app/src/components/viewer/DocumentViewer.tsx
@@ -12,6 +12,7 @@ import {
   documentGroupsAtom,
   activePrimaryGroupIdAtom,
 } from "../../atoms/files";
+import { MOCK_DOCUMENT_PDF } from "../../data/files";
 import { PageHighlights } from "./PageHighlights";
 import { FloatingMenu } from "./FloatingMenu";
 import { ActionBar } from "./ActionBar";
@@ -75,9 +76,7 @@ export function DocumentViewer({ actionBarMenu, showMinimap = true, fileOverride
     // group so the viewer still renders something.
     return files.find((f) => f.groupId === resolvedActiveId) ?? null;
   }, [files, resolvedActiveId, language, fileOverride]);
-  const filePath =
-    activeFile?.url ??
-    "/docs/Velasquez-Rodriguez_v_Honduras_Judgment_1988_EN.pdf";
+  const filePath = activeFile?.url ?? MOCK_DOCUMENT_PDF;
   const showLangFallback =
     !fileOverride && activeFile !== null && activeFile.language !== language;
 

--- a/app/src/data/cejil/profile.ts
+++ b/app/src/data/cejil/profile.ts
@@ -11,7 +11,7 @@ import type { FileEntry, DocumentGroup } from "../files";
 import type { Reference } from "../references";
 import type { CejilEntity, CejilFile } from "./types";
 import { cejilTemplates } from "./templates";
-import { chains } from "../../utils/chainTraversal";
+import { chains, type ChainGraph } from "../../utils/chainTraversal";
 import { cejilChainGraph, CEJIL_PERPETRATOR_CHAIN } from "./graph";
 import {
   registerCejilInherited,
@@ -153,24 +153,95 @@ const REL_CONN_CAP = 15;
 const CHAIN_JUDGE_CAP = 12;
 
 const templateIdByName = (name: string) => cejilTemplates.find((t) => t.name === name)?._id;
-const SENTENCIA_TEMPLATE = templateIdByName("Sentencia de la CorteIDH");
+const JUEZ_TEMPLATE = templateIdByName("Juez y/o Comisionado");
+
+/** Relation-type id of a `firmantes` (signing-judges) property. */
+const FIRMANTES_REL_ID = "5ab920b3163b080aaa44310f";
+/** Template ids of documents that carry a `firmantes` relationship (Sentencia,
+ *  Resolución, Voto Separado, Informe de Fondo, …) — the ones whose signing
+ *  judges we can surface WITH inherited país directly, one hop from the doc,
+ *  rather than only reaching them from a Causa via the full chain. */
+const SIGNING_DOC_TEMPLATES = new Set(
+  cejilTemplates
+    .filter((t) =>
+      (t.properties || []).some((p) => p.type === "relationship" && p.relationType === FIRMANTES_REL_ID),
+    )
+    .map((t) => t._id),
+);
+
+const LANGS_ARR: Language[] = ["EN", "ES", "FR", "AR"];
+
+/** Signing judges for an entity + each judge's inherited país (registered into
+ *  the inherited registry). Two routes to the same Juez → País hop:
+ *   - a **Causa** reaches its judges through its Sentencia — the full
+ *     Causa → Sentencia → Juez → País chain;
+ *   - a **signing document** (Sentencia/Resolución/…) connects to its judges
+ *     directly, so it walks only the last two segments (Juez, then País).
+ *  Returns deduped judge ids, or null when the entity has no signing judges. */
+function signingJudges(graph: ChainGraph, sharedId: string, template: string): string[] | null {
+  let segments = CEJIL_PERPETRATOR_CHAIN.segments;
+  let judgeIdx = 2; // [Causa, Sentencia, Juez, País]
+  let paisIdx = 3;
+  if (template !== CEJIL_PERPETRATOR_CHAIN.rootTypeId) {
+    if (!SIGNING_DOC_TEMPLATES.has(template)) return null;
+    segments = CEJIL_PERPETRATOR_CHAIN.segments.slice(1); // [Firmantes→Juez, País→País]
+    judgeIdx = 1; // [Doc, Juez, País]
+    paisIdx = 2;
+  }
+  const { tuples } = chains(graph, sharedId, segments, { maxPaths: 400 });
+  const judges: string[] = [];
+  const seen = new Set<string>();
+  for (const t of tuples) {
+    const judge = t[judgeIdx]?.entityId;
+    if (!judge || seen.has(judge)) continue;
+    seen.add(judge);
+    judges.push(judge);
+    const pais = t[paisIdx] ? graph.titleOf(t[paisIdx].entityId) : undefined;
+    if (pais) for (const l of LANGS_ARR) registerCejilInherited(judge, CEJIL_INHERIT_FIRMANTE_PAIS, l, pais);
+  }
+  return judges.length ? judges : null;
+}
 
 /** Relationship fields for a CEJIL entity, surfaced in the Metadata view.
  *
- *  1. Direct connections grouped by relation type → one link-only field each
- *     (capped). Makes every CEJIL entity show its graph neighbours.
- *  2. For a Causa: a chain-derived "Jueces firmantes" field that traverses
- *     Causa → Sentencia → Juez and INHERITS each judge's País (one more hop),
- *     pre-resolved into the inherited registry. The headline inheritance demo. */
+ *  1. Signing judges (+ inherited País) as the lead field — for a Causa via the
+ *     full chain, for a signing document directly (see `signingJudges`). This is
+ *     the inheritance surface; when present it replaces the raw "Firmantes"
+ *     link-only group so judges aren't listed twice.
+ *  2. Direct connections grouped by relation type → one link-only field each
+ *     (capped). Makes every CEJIL entity show its remaining graph neighbours. */
 function cejilRelationshipFields(sharedId: string, template: string): RelationshipMetadataField[] {
   const out: RelationshipMetadataField[] = [];
 
-  // 1. Direct connections grouped by relation type.
+  // 1. Signing judges + inherited país (Causa via chain, signing doc directly).
+  let promotedRelType: string | undefined;
+  const graph = cejilChainGraph();
+  if (graph) {
+    const judges = signingJudges(graph, sharedId, template);
+    if (judges) {
+      out.push({
+        id: `cejil-firmantes-${sharedId}`,
+        label: "Jueces firmantes",
+        type: "relationship",
+        relationType: "Firmantes",
+        targetTypeId: JUEZ_TEMPLATE ?? "",
+        inheritProperty: CEJIL_INHERIT_FIRMANTE_PAIS,
+        inheritLabel: "País",
+        connectedEntityIds: judges.slice(0, CHAIN_JUDGE_CAP),
+        totalConnected: judges.length,
+        readOnly: true,
+      });
+      promotedRelType = "Firmantes"; // shown inherited above — don't repeat below
+    }
+  }
+
+  // 2. Direct connections grouped by relation type (skip the promoted group).
   const rels = cejilRelsByEntity().get(sharedId) || [];
   const byType = new Map<string, { ids: string[]; seen: Set<string> }>();
   for (const r of rels) {
     const other = r.from === sharedId ? r.to : r.from;
     const typeName = r.typeName || "Relacionado";
+    if (typeName === promotedRelType) continue;
     let g = byType.get(typeName);
     if (!g) byType.set(typeName, (g = { ids: [], seen: new Set() }));
     if (!g.seen.has(other)) {
@@ -189,40 +260,6 @@ function cejilRelationshipFields(sharedId: string, template: string): Relationsh
       totalConnected: g.ids.length,
       readOnly: true,
     });
-  }
-
-  // 2. Causa → signing judges (+ inherited país), via the chain engine.
-  if (template === CEJIL_PERPETRATOR_CHAIN.rootTypeId) {
-    const graph = cejilChainGraph();
-    if (graph) {
-      const { tuples } = chains(graph, sharedId, CEJIL_PERPETRATOR_CHAIN.segments, { maxPaths: 400 });
-      // Dedupe judges across all paths first, so the cap can report a true total.
-      const judges: string[] = [];
-      const seen = new Set<string>();
-      for (const t of tuples) {
-        const judge = t[2]?.entityId; // Causa, Sentencia, Juez, País
-        const pais = t[3] ? graph.titleOf(t[3].entityId) : undefined;
-        if (!judge || seen.has(judge)) continue;
-        seen.add(judge);
-        judges.push(judge);
-        if (pais) for (const l of ["EN", "ES", "FR", "AR"] as Language[])
-          registerCejilInherited(judge, CEJIL_INHERIT_FIRMANTE_PAIS, l, pais);
-      }
-      if (judges.length) {
-        out.unshift({
-          id: `cejil-firmantes-${sharedId}`,
-          label: "Jueces firmantes",
-          type: "relationship",
-          relationType: "Firmantes",
-          targetTypeId: SENTENCIA_TEMPLATE ? templateIdByName("Juez y/o Comisionado") ?? "" : "",
-          inheritProperty: CEJIL_INHERIT_FIRMANTE_PAIS,
-          inheritLabel: "País",
-          connectedEntityIds: judges.slice(0, CHAIN_JUDGE_CAP),
-          totalConnected: judges.length,
-          readOnly: true,
-        });
-      }
-    }
   }
 
   return out;

--- a/app/src/data/files.ts
+++ b/app/src/data/files.ts
@@ -61,6 +61,21 @@ export const DOC_VELASQUEZ_ES = "/docs/Velasquez-Rodriguez_c_Honduras_Sentencia_
 export const DOC_GELMAN_EN    = "/docs/Gelman_v_Uruguay_Judgment_2011_EN.pdf";
 export const DOC_GELMAN_ES    = "/docs/Gelman_c_Uruguay_Sentencia_2011_ES.pdf";
 
+/** Neutral placeholder PDF shown wherever an entity has no bundled document —
+ *  the real CEJIL PDFs aren't all shipped in this sample. One file, used
+ *  everywhere an empty document pane would otherwise appear. */
+export const MOCK_DOCUMENT_PDF = "/cejil-docs/sample-document.pdf";
+export const MOCK_DOCUMENT_FILE: FileEntry = {
+  id: "mock-document",
+  groupId: "mock-document",
+  name: "sample-document.pdf",
+  type: "pdf",
+  size: "1 KB",
+  language: "EN",
+  modified: "",
+  url: MOCK_DOCUMENT_PDF,
+};
+
 export const files: FileEntry[] = [
   // Judgment — 4 translations
   {

--- a/app/src/views/LibraryView.tsx
+++ b/app/src/views/LibraryView.tsx
@@ -473,7 +473,7 @@ export function LibraryView() {
             No entities match your filters.
           </div>
         ) : viewMode === "cards" ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 items-start">
             {shown.map((e) => (
               <EntityCard
                 key={e.id}

--- a/app/src/views/MetadataView.tsx
+++ b/app/src/views/MetadataView.tsx
@@ -9,6 +9,7 @@ import { MetadataCard, Property, PropertyRow } from "../components/metadata/Meta
 import { spanClass, fieldSpan } from "../components/metadata/cardSpan";
 import { ConnectionGroupCard } from "../components/metadata/ConnectionGroupCard";
 import { RelationshipFieldCard } from "../components/metadata/RelationshipFieldCard";
+import { RelationshipCards } from "../components/metadata/RelationshipCards";
 import { RelationshipFieldEditor } from "../components/metadata/RelationshipFieldEditor";
 import { TemplateStructure } from "../components/relationships/TemplateStructure";
 import { EntityOverlay } from "../components/relationships/EntityOverlay";
@@ -86,12 +87,9 @@ export function MetadataView({ tabs, activeTab, onTabChange, onBack }: MetadataV
 
 function MetadataReadBody({ onEdit, menuSlot }: { onEdit: () => void; menuSlot?: ReactNode }) {
   const language = useAtom(languageAtom)[0];
-  const getProp = makeEntityPropReader(useAtomValue(entityMetadataAtom));
   const profile = getEntityProfile(useAtomValue(focusedEntityIdAtom));
   const allFields = profile.metadata[language];
   const fields = allFields.filter((f): f is MetadataField => f.type !== "relationship");
-  const relFields = allFields.filter((f): f is RelationshipMetadataField => f.type === "relationship");
-  const { groups, singles } = groupConnections(relFields, language, getProp);
   const pdf = profile.pdfMetadata?.[language];
   const notify = useNotify();
 
@@ -158,23 +156,10 @@ function MetadataReadBody({ onEdit, menuSlot }: { onEdit: () => void; menuSlot?:
             );
           })}
 
-          {/* Relationship / inherited fields. Shared connections (multi-
-              inheritance) render as one grouped table; standalone relationship
-              fields get their own card. A plain band separates them from the
-              scalar fields above — no border/colour accent. */}
-          {(groups.length > 0 || singles.length > 0) && (
-            <div className={`${spanClass("full")} mt-2 flex items-center`}>
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-ink-tertiary">
-                Relationships
-              </h3>
-            </div>
-          )}
-          {groups.map((group) => (
-            <ConnectionGroupCard key={group.connectionKey} group={group} />
-          ))}
-          {singles.map((field) => (
-            <RelationshipFieldCard key={field.id} field={field} />
-          ))}
+          {/* Relationship / inherited fields — shared with the drawers via
+              RelationshipCards so they can't drift. Shared connections render as
+              a grouped table; standalone relationship fields get their own card. */}
+          <RelationshipCards profile={profile} language={language} />
         </div>
       </div>
 

--- a/app/src/views/MetadataView.tsx
+++ b/app/src/views/MetadataView.tsx
@@ -99,7 +99,7 @@ function MetadataReadBody({ onEdit, menuSlot }: { onEdit: () => void; menuSlot?:
 
       {/* Scrollable metadata body — responsive grid */}
       <div className="flex-1 overflow-auto px-4 py-2 pb-8">
-        <div className="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid gap-3 items-start grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
           {profile.hasDocument && (
             <MetadataCard title="Document" className="hidden md:block md:col-span-2 xl:col-span-1 md:row-span-2">
               <div className="flex items-center justify-center bg-warm rounded-md overflow-hidden h-[200px]">

--- a/app/src/views/RelationshipsView.tsx
+++ b/app/src/views/RelationshipsView.tsx
@@ -4,6 +4,7 @@ import { scopedReferencesAtom, toastsAtom } from "../atoms/references";
 import { languageAtom, type Language } from "../atoms/language";
 import { focusedEntityIdAtom } from "../atoms/focusedEntity";
 import { getEntityProfile } from "../data/entityProfiles";
+import { MOCK_DOCUMENT_FILE } from "../data/files";
 import {
   viewAtom,
   groupByAtom,
@@ -211,9 +212,9 @@ export function RelationshipsView({ tabs, activeTab, onTabChange, onBack }: Prop
           {profile.hasDocument ? (
             <DocumentViewer showMinimap={!hideMinimap} />
           ) : (
-            <div className="flex-1 flex items-center justify-center p-6 text-center">
-              <p className="text-sm text-ink-muted">This entity has no document.</p>
-            </div>
+            /* No bundled document — show the shared placeholder PDF rather than a
+               bare empty state (the real doc isn't shipped in this sample). */
+            <DocumentViewer fileOverride={MOCK_DOCUMENT_FILE} showMinimap={false} />
           )}
           <ConfirmDialog
             open={deleteTarget !== null}


### PR DESCRIPTION
Four related improvements to CEJIL entity display, all verified live and `tsc` + `vite build` green.

## Changes
- **Widen signing-judge → País inheritance to documents** (`profile.ts`) — only Causas surfaced the "Jueces firmantes" inherited field (via the full Causa→Sentencia→Juez→País chain). Signing documents (Sentencia, Resolución, Voto Separado, Informe de Fondo, …) connect to their judges directly, so they now inherit each judge's País one hop closer (last 2 chain segments). Unified in `signingJudges()`; the inherited field replaces the raw link-only "Firmantes" group so judges aren't listed twice. Verified on the Cordero Bernal sentencia.
- **Show relationship/inherited props in the drawers** — the drawer metadata bodies dropped relationship fields (and `MetadataDrawerContent` was hardcoded to the mock `e3` globals). Extracted the Relationships section into a shared, profile-driven `RelationshipCards` component rendered in the main Metadata view AND all drawer bodies (`EntityDrawerPreview`, `MetadataDrawerContent`), so they can't drift.
- **Placeholder PDF for doc-less entities** — de-LFS left many CEJIL entities (Audiencias, geolocations, judges, países) with no bundled PDF, so the document pane showed a bare "This entity has no document." Added one neutral placeholder (`public/cejil-docs/sample-document.pdf`) rendered there via the existing viewer, and made it the `DocumentViewer` generic fallback. `hasDocument` is unchanged, so Library "has document" indicators stay honest.
- **Library card fit** — grid rows stretched every card to the tallest sibling (`h-full` + default `items-stretch`), opening a large empty gap above short cards' footers. Cards now size to content (`items-start`, no `h-full`).

## Verification
- `tsc --noEmit` + `vite build` green.
- Live: doc inheritance (Cordero Bernal), drawer relationship cards (reference drawer), placeholder PDF (renders + serves), card fit (library grid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)