### PR TITLE
Library: a timeline view, a map that tells the truth, and settings that go somewhere

### DIFF
--- a/app/src/atoms/library.ts
+++ b/app/src/atoms/library.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import { dataSourceAtom, type DataSource } from "./dataSource";
 
 /** Library search box. */
 export const libraryQueryAtom = atom("");
@@ -57,8 +58,25 @@ export const libraryChainFiltersAtom = atom<
 >({});
 
 /** Results layout. */
-export type LibraryViewMode = "cards" | "list" | "map";
+export type LibraryViewMode = "cards" | "list" | "map" | "timeline";
 export const libraryViewModeAtom = atom<LibraryViewMode>("cards");
+
+/** Timeline body flavour — four ways to read the same chronology:
+ *  - `rail`     the text-references minimap on a vertical time track: dots and
+ *               counted clusters that fan out into their members. Navigation —
+ *               clicking picks an entity, it does not filter.
+ *  - `density`  the same track as a volume histogram; clicking a bar FILTERS the
+ *               Library to that period.
+ *  - `spine`    a proportional chronology — every entity at its exact instant
+ *  - `lanes`    a template × period grid */
+export type TimelineLayout = "rail" | "density" | "spine" | "lanes";
+export const libraryTimelineLayoutAtom = atom<TimelineLayout>("rail");
+
+/** Track scope, mirroring the document minimap's whole-document / this-page
+ *  toggle: `all` plots the entire corpus span, `year` zooms the track to the
+ *  year you're currently reading (months, with ↑/↓ counts for the rest). */
+export type TimelineScope = "all" | "year";
+export const libraryTimelineScopeAtom = atom<TimelineScope>("all");
 
 /** Which information pieces the results show — a key is visible unless explicitly
  *  false, so the default (`{}`) shows everything. Driven by the header "Display"
@@ -85,6 +103,24 @@ export const librarySortDirAtom = atom<LibrarySortDir>("desc");
 /** Natural direction for a freshly-picked sort key: text → A→Z, value → high→low. */
 export const defaultSortDir = (key: LibrarySort): LibrarySortDir =>
   key === "title" || key === "type" || key === "country" ? "asc" : "desc";
+
+/** Switch collection. Template ids, countries and descriptors are per-source, so
+ *  every facet and the open preview have to go with it — this lives in an atom
+ *  (not in the view) because the collection picker now sits in the navbar, and
+ *  two call-sites clearing "most of" the facets would drift. */
+export const selectDataSourceAtom = atom(null, (_get, set, source: DataSource) => {
+  set(dataSourceAtom, source);
+  set(libraryTypeFiltersAtom, {});
+  set(libraryCountryFiltersAtom, {});
+  set(libraryStatusFiltersAtom, {});
+  set(libraryDescriptorFiltersAtom, {});
+  set(libraryInheritedFiltersAtom, {});
+  set(libraryChainFiltersAtom, {});
+  set(libraryDateFromAtom, "");
+  set(libraryDateToAtom, "");
+  set(librarySelectedEntityIdAtom, null);
+  set(librarySelectedClusterAtom, null);
+});
 
 /** Count of active filters (search + each selected type + has-doc + countries). */
 export const libraryActiveFilterCountAtom = atom((get) => {

--- a/app/src/atoms/library.ts
+++ b/app/src/atoms/library.ts
@@ -122,6 +122,24 @@ export const selectDataSourceAtom = atom(null, (_get, set, source: DataSource) =
   set(librarySelectedClusterAtom, null);
 });
 
+/** Clear every filter. ONE definition: the Filters panel and the view each had
+ *  their own, and they had already drifted — the panel's forgot the search box,
+ *  the view's forgot the AND/OR modes. */
+export const clearLibraryFiltersAtom = atom(null, (_get, set) => {
+  set(libraryQueryAtom, "");
+  set(libraryTypeFiltersAtom, {});
+  set(libraryHasDocAtom, false);
+  set(libraryStatusFiltersAtom, {});
+  set(libraryCountryFiltersAtom, {});
+  set(libraryCountryModeAtom, "OR");
+  set(libraryDescriptorFiltersAtom, {});
+  set(libraryDescriptorModeAtom, "OR");
+  set(libraryDateFromAtom, "");
+  set(libraryDateToAtom, "");
+  set(libraryInheritedFiltersAtom, {});
+  set(libraryChainFiltersAtom, {});
+});
+
 /** Count of active filters (search + each selected type + has-doc + countries). */
 export const libraryActiveFilterCountAtom = atom((get) => {
   let n = get(libraryQueryAtom).trim() ? 1 : 0;

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -19,10 +19,14 @@ import {
   Upload,
   Menu,
   Sparkles,
+  ChevronDown,
+  Check,
 } from "lucide-react";
 import type { Theme } from "../../atoms/theme";
 import type { AppView } from "../../atoms/navigation";
 import { breakpointAtom } from "../../atoms/viewport";
+import { dataSourceAtom, type DataSource } from "../../atoms/dataSource";
+import { selectDataSourceAtom } from "../../atoms/library";
 import { focusedEntityIdAtom } from "../../atoms/focusedEntity";
 import { getEntity } from "../../data/entities";
 import { agentOpenAtom, shortcutLabel } from "../../atoms/agent";
@@ -42,9 +46,13 @@ interface NavbarProps {
 export function Navbar({ onLogoClick, appView = "entity", onNavigate, theme, onToggleTheme, rtl, onToggleRtl }: NavbarProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [toolsOpen, setToolsOpen] = useState(false);
+  const [collectionOpen, setCollectionOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const settingsRef = useRef<HTMLDivElement>(null);
   const toolsRef = useRef<HTMLDivElement>(null);
+  const collectionRef = useRef<HTMLDivElement>(null);
+  const dataSource = useAtomValue(dataSourceAtom);
+  const selectSource = useSetAtom(selectDataSourceAtom);
   const [breakpoint] = useAtom(breakpointAtom);
   const isMobile = breakpoint === "mobile";
   const openAgent = useSetAtom(agentOpenAtom);
@@ -55,7 +63,7 @@ export function Navbar({ onLogoClick, appView = "entity", onNavigate, theme, onT
   const themeLabel = theme === "dark" ? "Dark" : theme === "auto" ? "Auto" : "Light";
 
   useEffect(() => {
-    if (!settingsOpen && !toolsOpen) return;
+    if (!settingsOpen && !toolsOpen && !collectionOpen) return;
     const handleClick = (e: MouseEvent) => {
       if (settingsOpen && settingsRef.current && !settingsRef.current.contains(e.target as Node)) {
         setSettingsOpen(false);
@@ -63,12 +71,25 @@ export function Navbar({ onLogoClick, appView = "entity", onNavigate, theme, onT
       if (toolsOpen && toolsRef.current && !toolsRef.current.contains(e.target as Node)) {
         setToolsOpen(false);
       }
+      if (
+        collectionOpen &&
+        collectionRef.current &&
+        !collectionRef.current.contains(e.target as Node)
+      ) {
+        setCollectionOpen(false);
+      }
     };
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
-  }, [settingsOpen, toolsOpen]);
+  }, [settingsOpen, toolsOpen, collectionOpen]);
 
   const showingCatalog = appView === "catalog";
+
+  const COLLECTIONS: { id: DataSource; label: string; detail: string }[] = [
+    { id: "mock", label: "Sample", detail: "Curated demo entities" },
+    { id: "cejil", label: "CEJIL", detail: "Published corpus · 4,398" },
+  ];
+  const collection = COLLECTIONS.find((c) => c.id === dataSource) ?? COLLECTIONS[0];
 
   const toolsItems = [
     { id: "processes", label: "Processes", icon: Cog, enabled: false },
@@ -121,16 +142,84 @@ export function Navbar({ onLogoClick, appView = "entity", onNavigate, theme, onT
                 </span>
               </div>
             ) : (
-              <button
-                onClick={() => onNavigate?.("library")}
-                className={`flex items-center gap-1.5 px-3 py-1 text-[13px] font-medium rounded-md transition-colors ${
-                  appView === "library"
-                    ? "text-ink bg-vellum"
-                    : "text-ink-secondary bg-warm hover:bg-parchment hover:text-ink"
-                }`}
-              >
-                <BookOpen size={14} /> Library
-              </button>
+              // Library + its COLLECTION picker. The dataset switch used to sit in
+              // the Library toolbar, where it was one more thing pushing the view
+              // controls around; it belongs to the destination, not the view.
+              <div ref={collectionRef} className="relative flex items-center">
+                <button
+                  onClick={() => onNavigate?.("library")}
+                  className={`flex items-center gap-1.5 ps-3 pe-2 py-1 text-[13px] font-medium rounded-s-md transition-colors ${
+                    appView === "library"
+                      ? "text-ink bg-vellum"
+                      : "text-ink-secondary bg-warm hover:bg-parchment hover:text-ink"
+                  }`}
+                >
+                  <BookOpen size={14} /> Library
+                </button>
+                <button
+                  onClick={() => {
+                    setCollectionOpen((o) => !o);
+                    setToolsOpen(false);
+                    setSettingsOpen(false);
+                  }}
+                  aria-haspopup="listbox"
+                  aria-expanded={collectionOpen}
+                  aria-label={`Collection: ${collection.label}`}
+                  title={`Collection: ${collection.label}`}
+                  className={`flex items-center gap-1 ps-1.5 pe-2 py-1 text-[13px] font-medium rounded-e-md transition-colors ${
+                    collectionOpen || appView === "library"
+                      ? "text-ink bg-vellum"
+                      : "text-ink-secondary bg-warm hover:bg-parchment hover:text-ink"
+                  }`}
+                  style={{ borderInlineStart: "1px solid var(--border-primary)" }}
+                >
+                  <span className="text-ink-tertiary">{collection.label}</span>
+                  <ChevronDown
+                    size={13}
+                    className={`text-ink-tertiary transition-transform ${collectionOpen ? "rotate-180" : ""}`}
+                  />
+                </button>
+                {collectionOpen && (
+                  <div
+                    role="listbox"
+                    className="absolute top-full mt-1.5 end-0 w-52 bg-paper border border-border rounded-lg shadow-lg overflow-hidden z-50 py-1"
+                  >
+                    <p className="px-3 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wide text-ink-tertiary">
+                      Collection
+                    </p>
+                    {COLLECTIONS.map((c) => {
+                      const on = c.id === dataSource;
+                      return (
+                        <button
+                          key={c.id}
+                          role="option"
+                          aria-selected={on}
+                          onClick={() => {
+                            selectSource(c.id);
+                            setCollectionOpen(false);
+                            onNavigate?.("library");
+                          }}
+                          className={`w-full flex items-start gap-2 px-3 py-1.5 text-start transition-colors cursor-pointer ${
+                            on ? "bg-vellum" : "hover:bg-warm"
+                          }`}
+                        >
+                          <span className="w-4 shrink-0 pt-0.5 text-carbon">
+                            {on && <Check size={13} />}
+                          </span>
+                          <span className="min-w-0">
+                            <span
+                              className={`block text-xs ${on ? "text-ink font-semibold" : "text-ink-secondary"}`}
+                            >
+                              {c.label}
+                            </span>
+                            <span className="block text-[10px] text-ink-tertiary">{c.detail}</span>
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
             )}
             <div className="relative" ref={toolsRef}>
               <button

--- a/app/src/components/library/ActiveFiltersButton.tsx
+++ b/app/src/components/library/ActiveFiltersButton.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { X, SlidersHorizontal } from "lucide-react";
+import {
+  libraryQueryAtom,
+  libraryTypeFiltersAtom,
+  libraryHasDocAtom,
+  libraryStatusFiltersAtom,
+  libraryCountryFiltersAtom,
+  libraryDescriptorFiltersAtom,
+  libraryDateFromAtom,
+  libraryDateToAtom,
+  libraryInheritedFiltersAtom,
+  libraryChainFiltersAtom,
+  libraryActiveFilterCountAtom,
+  clearLibraryFiltersAtom,
+  librarySelectedEntityIdAtom,
+  librarySelectedClusterAtom,
+} from "../../atoms/library";
+import { dataSourceAtom } from "../../atoms/dataSource";
+import { languageAtom } from "../../atoms/language";
+import { getEntityType } from "../../data/entities";
+import { libraryInheritedDefs } from "../../utils/libraryFacets";
+
+interface Item {
+  id: string;
+  group: string;
+  label: string;
+  color?: string;
+  remove: () => void;
+}
+
+/** The active-filter readout in the footer.
+ *
+ *  The Filters panel is the home of filters, but the drawer swaps it out for the
+ *  entity preview — so while you're reading an entity there was NO way to see
+ *  what was narrowing the results. This is that way: a popover listing every
+ *  active filter, each removable on its own, without closing the entity you're
+ *  looking at. "Open the Filters panel" is there when you want the full surface.
+ *
+ *  It sits in the footer, which is always mounted and whose height never changes,
+ *  so none of this moves the results. */
+export function ActiveFiltersButton() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const count = useAtomValue(libraryActiveFilterCountAtom);
+  const clearAll = useSetAtom(clearLibraryFiltersAtom);
+  const setSelectedId = useSetAtom(librarySelectedEntityIdAtom);
+  const setSelectedCluster = useSetAtom(librarySelectedClusterAtom);
+  const dataSource = useAtomValue(dataSourceAtom);
+  const language = useAtomValue(languageAtom);
+
+  const [query, setQuery] = useAtom(libraryQueryAtom);
+  const [typeFilters, setTypeFilters] = useAtom(libraryTypeFiltersAtom);
+  const [hasDocOnly, setHasDocOnly] = useAtom(libraryHasDocAtom);
+  const [statusFilters, setStatusFilters] = useAtom(libraryStatusFiltersAtom);
+  const [countryFilters, setCountryFilters] = useAtom(libraryCountryFiltersAtom);
+  const [descriptorFilters, setDescriptorFilters] = useAtom(libraryDescriptorFiltersAtom);
+  const [dateFrom, setDateFrom] = useAtom(libraryDateFromAtom);
+  const [dateTo, setDateTo] = useAtom(libraryDateToAtom);
+  const [inheritedFilters, setInheritedFilters] = useAtom(libraryInheritedFiltersAtom);
+  const [chainFilters, setChainFilters] = useAtom(libraryChainFiltersAtom);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const items = useMemo<Item[]>(() => {
+    const out: Item[] = [];
+    const drop = <T,>(set: (fn: (s: T) => T) => void, key: string) => () =>
+      set((s: T) => {
+        const next = { ...(s as object) } as Record<string, unknown>;
+        delete next[key];
+        return next as T;
+      });
+
+    if (query.trim())
+      out.push({
+        id: "q",
+        group: "Search",
+        label: `“${query.trim()}”`,
+        remove: () => setQuery(""),
+      });
+
+    for (const [id, on] of Object.entries(typeFilters))
+      if (on)
+        out.push({
+          id: `type-${id}`,
+          group: "Type",
+          label: getEntityType(id)?.name ?? id,
+          color: getEntityType(id)?.color,
+          remove: drop(setTypeFilters, id),
+        });
+
+    if (hasDocOnly)
+      out.push({
+        id: "doc",
+        group: "Document",
+        label: "Has a document",
+        remove: () => setHasDocOnly(false),
+      });
+
+    for (const [id, on] of Object.entries(statusFilters))
+      if (on)
+        out.push({
+          id: `status-${id}`,
+          group: "Status",
+          label: id === "published" ? "Published" : "Restricted",
+          remove: drop(setStatusFilters, id),
+        });
+
+    for (const [c, on] of Object.entries(countryFilters))
+      if (on)
+        out.push({
+          id: `country-${c}`,
+          group: "Country",
+          label: c,
+          remove: drop(setCountryFilters, c),
+        });
+
+    for (const [d, on] of Object.entries(descriptorFilters))
+      if (on)
+        out.push({
+          id: `desc-${d}`,
+          group: "Descriptor",
+          label: d,
+          remove: drop(setDescriptorFilters, d),
+        });
+
+    if (dateFrom || dateTo)
+      out.push({
+        id: "date",
+        group: "Date",
+        label: `${dateFrom || "…"} → ${dateTo || "…"}`,
+        remove: () => {
+          setDateFrom("");
+          setDateTo("");
+        },
+      });
+
+    const defs = libraryInheritedDefs(dataSource, language);
+    for (const [propId, vals] of Object.entries(inheritedFilters))
+      for (const [v, on] of Object.entries(vals))
+        if (on)
+          out.push({
+            id: `inh-${propId}-${v}`,
+            group: defs.find((d) => d.propId === propId)?.label ?? propId,
+            label: v,
+            remove: () =>
+              setInheritedFilters((s) => {
+                const next = { ...(s[propId] ?? {}) };
+                delete next[v];
+                return { ...s, [propId]: next };
+              }),
+          });
+
+    for (const [key, vals] of Object.entries(chainFilters))
+      for (const [v, on] of Object.entries(vals))
+        if (on)
+          out.push({
+            id: `chain-${key}-${v}`,
+            group: "Connected",
+            label: v,
+            remove: () =>
+              setChainFilters((s) => {
+                const next = { ...(s[key] ?? {}) };
+                delete next[v];
+                return { ...s, [key]: next };
+              }),
+          });
+
+    return out;
+  }, [
+    query,
+    typeFilters,
+    hasDocOnly,
+    statusFilters,
+    countryFilters,
+    descriptorFilters,
+    dateFrom,
+    dateTo,
+    inheritedFilters,
+    chainFilters,
+    dataSource,
+    language,
+    setQuery,
+    setTypeFilters,
+    setHasDocOnly,
+    setStatusFilters,
+    setCountryFilters,
+    setDescriptorFilters,
+    setDateFrom,
+    setDateTo,
+    setInheritedFilters,
+    setChainFilters,
+  ]);
+
+  if (count === 0) return null;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className={`inline-flex items-center gap-1.5 px-1.5 h-5 text-[11px] font-medium rounded-md
+          transition-colors cursor-pointer ${
+            open ? "bg-warm text-ink" : "text-ink-secondary hover:bg-warm hover:text-ink"
+          }`}
+      >
+        <span
+          className="w-1.5 h-1.5 rounded-full"
+          style={{ backgroundColor: "var(--accent-blue)" }}
+        />
+        {count} {count === 1 ? "filter" : "filters"}
+      </button>
+
+      {open && (
+        // Opens UPWARD — the button lives in the footer.
+        <div
+          role="dialog"
+          aria-label="Active filters"
+          className="absolute bottom-full mb-1.5 start-0 z-50 w-72 bg-paper border border-border rounded-md shadow-lg
+            animate-fade-in-up overflow-hidden"
+        >
+          <div className="flex items-center gap-2 px-3 py-2" style={{ borderBottom: "1px solid var(--border-soft)" }}>
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-ink-tertiary">
+              Active filters
+            </span>
+            <button
+              onClick={() => {
+                clearAll();
+                setOpen(false);
+              }}
+              className="ms-auto px-1.5 h-5 text-[11px] font-medium rounded text-ink-tertiary hover:bg-parchment hover:text-ink transition-colors cursor-pointer"
+            >
+              Clear all
+            </button>
+          </div>
+
+          <ul className="max-h-64 overflow-auto py-1">
+            {items.map((it) => (
+              <li key={it.id}>
+                {/* Full-width row: removing a filter here can't shift the NEXT
+                    row under the cursor sideways, the way a wrapping chip row
+                    did — the list only ever collapses downward. */}
+                <div className="group flex items-center gap-2 px-3 py-1.5 hover:bg-warm transition-colors">
+                  {it.color ? (
+                    <span
+                      className="w-1.5 h-1.5 rounded-[2px] shrink-0"
+                      style={{ backgroundColor: it.color }}
+                    />
+                  ) : (
+                    <span className="w-1.5 shrink-0" />
+                  )}
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-[10px] text-ink-tertiary leading-tight">
+                      {it.group}
+                    </span>
+                    <span className="block text-xs text-ink truncate">{it.label}</span>
+                  </span>
+                  {/* Always visible: this is a list OF things to remove, so
+                      hiding the remove until hover would be hiding the point. */}
+                  <button
+                    onClick={it.remove}
+                    aria-label={`Remove ${it.group}: ${it.label}`}
+                    className="shrink-0 p-1 rounded text-ink-muted hover:bg-parchment hover:text-ink
+                      transition-colors cursor-pointer
+                      focus:outline-none focus-visible:ring-2 focus-visible:ring-carbon/30"
+                  >
+                    <X size={12} />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <button
+            onClick={() => {
+              setSelectedId(null);
+              setSelectedCluster(null);
+              setOpen(false);
+            }}
+            className="w-full flex items-center gap-1.5 px-3 py-2 text-[11px] font-medium text-ink-secondary
+              hover:bg-warm hover:text-ink transition-colors cursor-pointer"
+            style={{ borderTop: "1px solid var(--border-soft)" }}
+          >
+            <SlidersHorizontal size={12} className="text-ink-tertiary" />
+            Open the Filters panel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/library/BucketBreakdown.tsx
+++ b/app/src/components/library/BucketBreakdown.tsx
@@ -1,0 +1,65 @@
+import type { TypeSlice } from "../../utils/timeline";
+
+/** What a period is made of — the tooltip body shared by the timeline's density
+ *  rail (whose stacked bars need a key) and the brush strip (whose silhouette
+ *  carries no colour at all, so this is the ONLY place its composition shows). */
+export function BucketBreakdown({
+  label,
+  total,
+  slices,
+  max = 5,
+}: {
+  label: string;
+  total: number;
+  slices: TypeSlice[];
+  max?: number;
+}) {
+  // Sorted by count HERE, not by the chart's global stack order. The stack has to
+  // keep one order across every bar to stay comparable, but a readout that lists
+  // "Causa 8" above "Informe 29" just looks broken.
+  const ranked = [...slices].sort((a, b) => b.n - a.n);
+  const top = ranked.slice(0, max);
+  const rest = ranked.length - top.length;
+  return (
+    <span className="block text-start">
+      <span className="block font-semibold tabular-nums pb-0.5">
+        {label} · {total.toLocaleString()}
+      </span>
+      {top.map((s) => (
+        <span key={s.typeId} className="flex items-center gap-1.5 leading-[14px]">
+          <span className="w-1.5 h-1.5 rounded-[2px] shrink-0" style={{ backgroundColor: s.color }} />
+          <span className="opacity-80">{s.name}</span>
+          <span className="ms-auto ps-3 tabular-nums">{s.n.toLocaleString()}</span>
+        </span>
+      ))}
+      {rest > 0 && <span className="block opacity-60 leading-[14px]">+{rest} more</span>}
+    </span>
+  );
+}
+
+/** The dark floating label both charts use. `anchor` picks which side it grows
+ *  toward — HTML overlay, never an SVG <text> inside a scaled viewBox. */
+export function ChartTip({
+  children,
+  anchor = "start",
+}: {
+  children: React.ReactNode;
+  anchor?: "start" | "above";
+}) {
+  return (
+    <span
+      className="absolute z-50 pointer-events-none text-[10px] font-medium whitespace-nowrap rounded-md"
+      style={{
+        ...(anchor === "start"
+          ? { right: "calc(100% + 6px)", top: "50%", transform: "translateY(-50%)" }
+          : { bottom: "calc(100% + 6px)", left: "50%", transform: "translateX(-50%)" }),
+        padding: "4px 7px",
+        backgroundColor: "var(--text-primary)",
+        color: "var(--bg-surface)",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/app/src/components/library/DisplayMenu.tsx
+++ b/app/src/components/library/DisplayMenu.tsx
@@ -1,9 +1,12 @@
 import { useState } from "react";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { SlidersHorizontal, Check } from "lucide-react";
 import {
   libraryInfoAtom,
+  libraryViewModeAtom,
+  libraryTimelineLayoutAtom,
   type LibraryInfoKey,
+  type TimelineLayout,
 } from "../../atoms/library";
 
 const ITEMS: { key: LibraryInfoKey; label: string }[] = [
@@ -14,59 +17,124 @@ const ITEMS: { key: LibraryInfoKey; label: string }[] = [
   { key: "connections", label: "Connections" },
 ];
 
-/** Header control to show less / more information in the results — toggles which
- *  info pieces appear on the cards and the list table. A key is shown unless set
- *  to false. */
+const LAYOUTS: { id: TimelineLayout; label: string; detail: string }[] = [
+  { id: "rail", label: "Rail", detail: "Periods on a track, fan out" },
+  { id: "density", label: "Density", detail: "Volume per period, click to filter" },
+  { id: "spine", label: "Spine", detail: "Every entity at its exact date" },
+  { id: "lanes", label: "Lanes", detail: "Template × period grid" },
+];
+
+/** Header control for how the results are drawn: which info pieces the cards and
+ *  rows carry, plus the view-specific modifiers.
+ *
+ *  Icon-only trigger at a fixed 2rem square, and the timeline's layout picker
+ *  lives INSIDE the popover — a control that only exists in one view is a control
+ *  that shoves every other control sideways when you switch views. The toolbar
+ *  row is now the same width whatever is selected. */
 export function DisplayMenu() {
   const [info, setInfo] = useAtom(libraryInfoAtom);
+  const [layout, setLayout] = useAtom(libraryTimelineLayoutAtom);
+  const viewMode = useAtomValue(libraryViewModeAtom);
   const [open, setOpen] = useState(false);
+
   const hiddenCount = ITEMS.filter((i) => info[i.key] === false).length;
-  const toggle = (key: LibraryInfoKey) =>
-    setInfo((s) => ({ ...s, [key]: s[key] === false }));
+  // The map draws no cards or rows, so the info toggles have nothing to act on.
+  const showInfo = viewMode !== "map";
+  const showLayouts = viewMode === "timeline";
+  const toggle = (key: LibraryInfoKey) => setInfo((s) => ({ ...s, [key]: s[key] === false }));
 
   return (
     <div className="relative">
       <button
         onClick={() => setOpen((o) => !o)}
         aria-label="Display options"
-        className={`inline-flex items-center gap-1.5 px-2.5 h-8 text-xs font-medium rounded-md transition-colors cursor-pointer ${
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className={`relative inline-flex items-center justify-center w-8 h-8 rounded-md transition-colors cursor-pointer ${
           open || hiddenCount > 0
             ? "bg-vellum text-ink"
             : "bg-warm text-ink-secondary hover:bg-parchment hover:text-ink"
         }`}
       >
         <SlidersHorizontal size={14} />
-        <span className="hidden lg:inline">Display</span>
         {hiddenCount > 0 && (
-          <span className="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-ink/10 text-[10px] font-semibold tabular-nums">
-            {ITEMS.length - hiddenCount}
-          </span>
+          <span
+            className="absolute -top-0.5 -end-0.5 w-1.5 h-1.5 rounded-full"
+            style={{ backgroundColor: "var(--accent-blue)" }}
+          />
         )}
       </button>
       {open && (
         <>
           <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} aria-hidden />
-          <div className="absolute end-0 mt-1 z-40 w-44 bg-paper border border-border rounded-md shadow-lg p-1">
-            <p className="px-2 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wide text-ink-tertiary">
-              Show information
-            </p>
-            {ITEMS.map((it) => {
-              const shown = info[it.key] !== false;
-              return (
-                <button
-                  key={it.key}
-                  onClick={() => toggle(it.key)}
-                  className="w-full flex items-center gap-2 px-2 py-1.5 rounded hover:bg-warm transition-colors cursor-pointer text-start"
-                >
-                  <span className="w-4 shrink-0 flex items-center justify-center text-carbon">
-                    {shown && <Check size={13} />}
-                  </span>
-                  <span className={`text-xs ${shown ? "text-ink" : "text-ink-tertiary"}`}>
-                    {it.label}
-                  </span>
-                </button>
-              );
-            })}
+          <div className="absolute end-0 mt-1 z-40 w-52 bg-paper border border-border rounded-md shadow-lg p-1">
+            {showLayouts && (
+              <>
+                <p className="px-2 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wide text-ink-tertiary">
+                  Timeline layout
+                </p>
+                {LAYOUTS.map((l) => {
+                  const on = layout === l.id;
+                  return (
+                    <button
+                      key={l.id}
+                      onClick={() => setLayout(l.id)}
+                      aria-pressed={on}
+                      className="w-full flex items-start gap-2 px-2 py-1.5 rounded hover:bg-warm transition-colors cursor-pointer text-start"
+                    >
+                      <span className="w-4 shrink-0 pt-0.5 flex justify-center text-carbon">
+                        {on && <Check size={13} />}
+                      </span>
+                      <span className="min-w-0">
+                        <span
+                          className={`block text-xs ${on ? "text-ink font-semibold" : "text-ink-secondary"}`}
+                        >
+                          {l.label}
+                        </span>
+                        <span className="block text-[10px] text-ink-tertiary leading-tight">
+                          {l.detail}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                })}
+              </>
+            )}
+
+            {showInfo && (
+              <>
+                {showLayouts && (
+                  <div className="my-1 h-px" style={{ backgroundColor: "var(--border-soft)" }} />
+                )}
+                <p className="px-2 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wide text-ink-tertiary">
+                  Show information
+                </p>
+                {ITEMS.map((it) => {
+                  const shown = info[it.key] !== false;
+                  return (
+                    <button
+                      key={it.key}
+                      onClick={() => toggle(it.key)}
+                      aria-pressed={shown}
+                      className="w-full flex items-center gap-2 px-2 py-1.5 rounded hover:bg-warm transition-colors cursor-pointer text-start"
+                    >
+                      <span className="w-4 shrink-0 flex items-center justify-center text-carbon">
+                        {shown && <Check size={13} />}
+                      </span>
+                      <span className={`text-xs ${shown ? "text-ink" : "text-ink-tertiary"}`}>
+                        {it.label}
+                      </span>
+                    </button>
+                  );
+                })}
+              </>
+            )}
+
+            {!showInfo && !showLayouts && (
+              <p className="px-2 py-2 text-[11px] text-ink-tertiary">
+                No display options for this view.
+              </p>
+            )}
           </div>
         </>
       )}

--- a/app/src/components/library/EntityDrawerPreview.tsx
+++ b/app/src/components/library/EntityDrawerPreview.tsx
@@ -5,7 +5,7 @@ import { referencesAtom } from "../../atoms/references";
 import { librarySelectedEntityIdAtom } from "../../atoms/library";
 import { openEntityAtom, focusEntityForPreviewAtom } from "../../atoms/focusedEntity";
 import { getEntity } from "../../data/entities";
-import { EntityPill } from "../shared/EntityPill";
+import { EntityIdentity } from "../shared/EntityIdentity";
 import { getEntityProfile } from "../../data/entityProfiles";
 import { isCejilEntity, cejilReferencesFor } from "../../data/cejil/profile";
 import { tabsForType } from "../../utils/entityTabs";
@@ -63,23 +63,14 @@ export function EntityDrawerPreview({ entityId }: { entityId: string }) {
           panel header. Tabs sit beneath it (flipped from the entity view so the
           drawer reads title-first). */}
       <div
-        className="flex items-start gap-2 px-3 py-2 shrink-0"
+        className="flex items-start gap-2 px-3 pt-3 pb-2.5 shrink-0"
         style={{ borderBottom: "1px solid var(--border-primary)" }}
       >
-        {/* Type tag stacked above the title — same treatment as EntityOverlay;
-            the tag's dot carries the entity colour. */}
-        <div className="min-w-0 flex-1 space-y-1">
-          <div>
-            <EntityPill typeId={entity?.typeId ?? ""} />
-          </div>
-          <div className="text-xs font-semibold text-ink truncate">
-            {entity?.title ?? "Unknown entity"}
-          </div>
-        </div>
+        <EntityIdentity entity={entity} />
         <button
           onClick={() => setSelected(null)}
           aria-label="Back to filters"
-          className="p-1.5 rounded-md hover:bg-warm text-ink-muted hover:text-ink transition-colors shrink-0"
+          className="-mt-0.5 p-1.5 rounded-md hover:bg-warm text-ink-muted hover:text-ink transition-colors shrink-0"
         >
           <X size={16} />
         </button>

--- a/app/src/components/library/LibraryFilters.tsx
+++ b/app/src/components/library/LibraryFilters.tsx
@@ -254,14 +254,39 @@ export function LibraryFilters() {
   return (
     <div className="flex flex-col h-full min-h-0 bg-warm">
       {/* Filters header — same height + divider as the main-view toolbar so the
-          pill aligns with the toolbar controls. */}
+          pill aligns with the toolbar controls.
+          This panel is now the ONLY place active filters live: the chip row that
+          used to sit above the results was a block that appeared and vanished,
+          shoving the whole result set up and down, and re-flowing under the
+          cursor as chips were removed. Filters are set here, so they are read
+          here — the ticked boxes already say what's on; the header just totals
+          them and offers the way out. The h-8 pill fixes the header's height, so
+          the count appearing changes nothing else. */}
       <div
-        className="shrink-0 px-3.5 py-2"
+        className="shrink-0 flex items-center gap-2 px-3.5 py-2"
         style={{ borderBottom: "1px solid var(--border-primary)" }}
       >
         <span className="inline-flex items-center px-3 h-8 text-[13px] font-semibold text-ink bg-vellum rounded-md">
           Filters
         </span>
+        {activeFilterCount > 0 && (
+          <>
+            <span className="inline-flex items-center gap-1.5 text-[11px] text-ink-tertiary tabular-nums">
+              <span
+                className="w-1.5 h-1.5 rounded-full"
+                style={{ backgroundColor: "var(--accent-blue)" }}
+              />
+              {activeFilterCount} active
+            </span>
+            <button
+              onClick={clearAll}
+              className="ms-auto px-2 h-6 text-[11px] font-medium rounded-md text-ink-tertiary
+                hover:bg-parchment hover:text-ink transition-colors cursor-pointer"
+            >
+              Clear all
+            </button>
+          </>
+        )}
       </div>
 
       {/* Facet cards — top padding matches the main content (py-3) so the first

--- a/app/src/components/library/LibraryFilters.tsx
+++ b/app/src/components/library/LibraryFilters.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { Play, Search, Lock, Globe, X, ChevronRight, Link2, type LucideIcon } from "lucide-react";
 import { dataSourceAtom, libraryEntitiesAtom, libraryTypesAtom } from "../../atoms/dataSource";
 import { getEntityType } from "../../data/entities";
@@ -19,6 +19,7 @@ import {
   libraryInheritedFiltersAtom,
   libraryChainFiltersAtom,
   libraryActiveFilterCountAtom,
+  clearLibraryFiltersAtom,
   type FacetMode,
 } from "../../atoms/library";
 import { typeHasDocument } from "../../data/entityProfiles";
@@ -176,19 +177,10 @@ export function LibraryFilters() {
   const toggleStatus = (id: string) => setStatusFilters((prev) => ({ ...prev, [id]: !prev[id] }));
   const toggleCountry = (c: string) => setCountryFilters((prev) => ({ ...prev, [c]: !prev[c] }));
   const toggleDescriptor = (d: string) => setDescriptorFilters((prev) => ({ ...prev, [d]: !prev[d] }));
-  const clearAll = () => {
-    setTypeFilters({});
-    setHasDocOnly(false);
-    setStatusFilters({});
-    setCountryFilters({});
-    setDescriptorFilters({});
-    setCountryMode("OR");
-    setDescriptorMode("OR");
-    setDateFrom("");
-    setDateTo("");
-    setInheritedFilters({});
-    setChainFilters({});
-  };
+  // One clear, shared with the footer readout (clearLibraryFiltersAtom). This
+  // used to be a local copy that forgot the search box, while the view's copy
+  // forgot the AND/OR modes — the two had already drifted.
+  const clearAll = useSetAtom(clearLibraryFiltersAtom);
   const toggleChain = (key: string, value: string) =>
     setChainFilters((s) => ({
       ...s,

--- a/app/src/components/library/LibraryMapView.tsx
+++ b/app/src/components/library/LibraryMapView.tsx
@@ -5,7 +5,7 @@ import worldData from "world-atlas/countries-110m.json";
 import { languageAtom } from "../../atoms/language";
 import { librarySelectedClusterAtom, librarySelectedEntityIdAtom } from "../../atoms/library";
 import { entityCountries } from "../../utils/libraryFacets";
-import type { Entity } from "../../data/entities";
+import { getEntity, type Entity } from "../../data/entities";
 
 interface Cluster {
   key: string;
@@ -35,12 +35,17 @@ export function LibraryMapView({ entities }: { entities: Entity[] }) {
       const c = m.get(key) ?? { key, label, lat: e.geo.lat, lng: e.geo.lng, count: 0, ids: [] };
       c.count += 1;
       c.ids.push(e.id);
+      // A pin now sits on a real coordinate, so most hold exactly one entity —
+      // an incident site, not a country. Name it after the entity; keep the
+      // country name only when the pin genuinely aggregates several.
+      c.label = c.count === 1 ? getEntity(e.id)?.title ?? label : label || c.label;
       m.set(key, c);
     }
     return [...m.values()];
   }, [entities, language]);
 
   const located = clusters.reduce((n, c) => n + c.count, 0);
+  const unlocated = entities.length - located;
   const openCluster = (c: Cluster) => {
     setSelectedId(null);
     setSelectedCluster({ label: c.label, ids: c.ids });
@@ -112,10 +117,18 @@ export function LibraryMapView({ entities }: { entities: Entity[] }) {
           </ZoomableGroup>
         </ComposableMap>
 
-        {/* Caption */}
+        {/* Caption — states what ISN'T here. Only entities with a real
+            geolocation property are plotted, and in a corpus like CEJIL that is
+            a small minority; without this the map reads as the whole library. */}
         <div className="absolute bottom-2 left-2 text-[11px] text-ink-tertiary bg-paper/70 backdrop-blur-sm rounded px-2 py-0.5">
-          {located} located {located === 1 ? "entity" : "entities"} · {clusters.length}{" "}
-          {clusters.length === 1 ? "place" : "places"}
+          {located.toLocaleString()} located {located === 1 ? "entity" : "entities"} ·{" "}
+          {clusters.length.toLocaleString()} {clusters.length === 1 ? "place" : "places"}
+          {unlocated > 0 && (
+            <span className="text-ink-muted">
+              {" · "}
+              {unlocated.toLocaleString()} with no geolocation
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/app/src/components/library/LibraryMapView.tsx
+++ b/app/src/components/library/LibraryMapView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { ComposableMap, Geographies, Geography, Graticule, Marker, ZoomableGroup } from "react-simple-maps";
 import worldData from "world-atlas/countries-110m.json";
@@ -7,46 +7,114 @@ import { librarySelectedClusterAtom, librarySelectedEntityIdAtom } from "../../a
 import { entityCountries } from "../../utils/libraryFacets";
 import { getEntity, type Entity } from "../../data/entities";
 
+const WIDTH = 800;
+const HEIGHT = 400;
+const SCALE = 127;
+const START_ZOOM = 1.6;
+
+/** How close two pins may sit, in ON-SCREEN units, before they merge. Compared
+ *  against projected distance ÷ zoom, so clusters break apart as you zoom in. */
+const CLUSTER_PX = 16;
+
+/* The map is a plain equirectangular projection with no rotation, so projecting
+ * and inverting is two lines of arithmetic — no need to pull d3-geo in as a
+ * direct dependency just to reach the same numbers react-simple-maps uses. */
+const project = (lng: number, lat: number): [number, number] => [
+  WIDTH / 2 + SCALE * (lng * (Math.PI / 180)),
+  HEIGHT / 2 - SCALE * (lat * (Math.PI / 180)),
+];
+const invert = (x: number, y: number): [number, number] => [
+  ((x - WIDTH / 2) / SCALE) * (180 / Math.PI),
+  ((HEIGHT / 2 - y) / SCALE) * (180 / Math.PI),
+];
+
 interface Cluster {
   key: string;
   label: string;
-  lat: number;
   lng: number;
+  lat: number;
   count: number;
   ids: string[];
 }
 
 /** Library geolocation view. Real world geography via react-simple-maps
- *  (equirectangular + graticule), styled to our tokens; pins cluster by country,
- *  sized by count, and clicking one toggles that country filter. */
+ *  (equirectangular + graticule), styled to our tokens.
+ *
+ *  Pins cluster by SCREEN PROXIMITY at the current zoom, not by identical
+ *  coordinates. They used to key on `${lat},${lng}` — fine when every entity sat
+ *  on a shared country centroid, but once the adapter started reading real
+ *  geolocation properties no two incidents shared a coordinate, so 352 pins each
+ *  reading "1" piled on top of each other into an unreadable mass. Zooming in
+ *  splits a cluster; zooming out merges it. */
 export function LibraryMapView({ entities }: { entities: Entity[] }) {
   const language = useAtomValue(languageAtom);
   const [selectedCluster, setSelectedCluster] = useAtom(librarySelectedClusterAtom);
   const setSelectedId = useSetAtom(librarySelectedEntityIdAtom);
+  const [zoom, setZoom] = useState(START_ZOOM);
+
+  // MUST be stable. react-simple-maps' useZoomPan lists onMove/onMoveEnd in the
+  // deps of the effect that attaches d3-zoom, so an inline arrow — a new function
+  // every render — makes it tear down and re-attach the zoom behaviour on each
+  // render. Re-attaching mid-gesture kills d3's "end" event, so onMoveEnd never
+  // fired, the zoom level never reached this component, and the clusters never
+  // re-computed. The map's own `center`/`zoom` props stay CONSTANT (uncontrolled)
+  // — useZoomPan's re-sync effect keys off those props, so leaving them fixed is
+  // what stops it yanking the map back to the initial view on every re-render.
+  const handleMoveEnd = useCallback(({ zoom: z }: { zoom: number }) => setZoom(z), []);
 
   const clusters = useMemo(() => {
-    const m = new Map<string, Cluster>();
-    for (const e of entities) {
-      if (!e.geo) continue;
-      const key = `${e.geo.lat},${e.geo.lng}`;
-      // entityCountries handles all sources: own title for país entities,
-      // adapter-supplied country (CEJIL), or the Sample native prop.
-      const label = entityCountries(e, language)[0] ?? "";
-      const c = m.get(key) ?? { key, label, lat: e.geo.lat, lng: e.geo.lng, count: 0, ids: [] };
-      c.count += 1;
-      c.ids.push(e.id);
-      // A pin now sits on a real coordinate, so most hold exactly one entity —
-      // an incident site, not a country. Name it after the entity; keep the
-      // country name only when the pin genuinely aggregates several.
-      c.label = c.count === 1 ? getEntity(e.id)?.title ?? label : label || c.label;
-      m.set(key, c);
+    const pts = entities
+      .filter((e) => e.geo)
+      .map((e) => {
+        const [x, y] = project(e.geo!.lng, e.geo!.lat);
+        return { e, x, y };
+      });
+
+    // Greedy proximity merge against a running centroid. n is in the hundreds,
+    // so the O(n·clusters) scan is far cheaper than pulling in a quadtree.
+    const threshold = CLUSTER_PX / zoom;
+    const t2 = threshold * threshold;
+    const acc: { x: number; y: number; sx: number; sy: number; ids: string[]; labels: string[] }[] = [];
+
+    for (const p of pts) {
+      const hit = acc.find((c) => (c.x - p.x) ** 2 + (c.y - p.y) ** 2 <= t2);
+      const label = entityCountries(p.e, language)[0] ?? "";
+      if (hit) {
+        hit.ids.push(p.e.id);
+        hit.labels.push(label);
+        hit.sx += p.x;
+        hit.sy += p.y;
+        hit.x = hit.sx / hit.ids.length;
+        hit.y = hit.sy / hit.ids.length;
+      } else {
+        acc.push({ x: p.x, y: p.y, sx: p.x, sy: p.y, ids: [p.e.id], labels: [label] });
+      }
     }
-    return [...m.values()];
-  }, [entities, language]);
+
+    return acc.map((c): Cluster => {
+      const [lng, lat] = invert(c.x, c.y);
+      // A lone pin is one incident — name it after the entity. A cluster is a
+      // place; name it after the country its members share, if they share one.
+      const countries = [...new Set(c.labels.filter(Boolean))];
+      const label =
+        c.ids.length === 1
+          ? getEntity(c.ids[0])?.title ?? countries[0] ?? "Location"
+          : countries.length === 1
+            ? countries[0]
+            : `${c.ids.length} locations`;
+      return { key: c.ids[0], label, lng, lat, count: c.ids.length, ids: c.ids };
+    });
+  }, [entities, language, zoom]);
 
   const located = clusters.reduce((n, c) => n + c.count, 0);
   const unlocated = entities.length - located;
-  const openCluster = (c: Cluster) => {
+
+  const open = (c: Cluster) => {
+    if (c.count === 1) {
+      setSelectedCluster(null);
+      setSelectedId(c.ids[0]);
+      return;
+    }
     setSelectedId(null);
     setSelectedCluster({ label: c.label, ids: c.ids });
   };
@@ -59,12 +127,18 @@ export function LibraryMapView({ entities }: { entities: Entity[] }) {
       >
         <ComposableMap
           projection="geoEquirectangular"
-          width={800}
-          height={400}
-          projectionConfig={{ scale: 127, center: [0, 0] }}
+          width={WIDTH}
+          height={HEIGHT}
+          projectionConfig={{ scale: SCALE, center: [0, 0] }}
           style={{ width: "100%", height: "100%" }}
         >
-          <ZoomableGroup center={[-60, -12]} zoom={1.6} minZoom={1} maxZoom={10}>
+          <ZoomableGroup
+            center={[-60, -12]}
+            zoom={START_ZOOM}
+            minZoom={1}
+            maxZoom={24}
+            onMoveEnd={handleMoveEnd}
+          >
             <Geographies geography={worldData as object}>
               {({ geographies }) =>
                 geographies.map((geo) => (
@@ -73,7 +147,7 @@ export function LibraryMapView({ entities }: { entities: Entity[] }) {
                     geography={geo}
                     fill="var(--bg-surface)"
                     stroke="var(--border-primary)"
-                    strokeWidth={0.4}
+                    strokeWidth={0.4 / zoom}
                     style={{
                       default: { outline: "none" },
                       hover: { outline: "none", fill: "var(--bg-surface)" },
@@ -84,33 +158,48 @@ export function LibraryMapView({ entities }: { entities: Entity[] }) {
               }
             </Geographies>
 
-            <Graticule stroke="var(--border-soft)" strokeWidth={0.35} step={[30, 30]} />
+            <Graticule stroke="var(--border-soft)" strokeWidth={0.35 / zoom} step={[30, 30]} />
 
             {clusters.map((c) => {
-              const r = Math.min(11, 5 + c.count * 1.1);
-              const active = selectedCluster?.label === c.label;
+              // ZoomableGroup scales its children, so every pin dimension is
+              // divided by the zoom to keep a constant on-screen size. Without
+              // this the markers balloon as you zoom and re-swamp the map.
+              const base = c.count === 1 ? 3.5 : 4.5 + Math.min(Math.sqrt(c.count) * 1.6, 7);
+              const r = base / zoom;
+              const active = selectedCluster?.ids.length === c.ids.length && selectedCluster?.label === c.label;
               return (
-                <Marker key={c.key} coordinates={[c.lng, c.lat]} onClick={() => openCluster(c)}>
+                <Marker key={c.key} coordinates={[c.lng, c.lat]} onClick={() => open(c)}>
                   <circle
                     r={r}
-                    strokeWidth={1}
+                    strokeWidth={1 / zoom}
                     style={{ cursor: "pointer" }}
-                    fill={active ? "var(--text-primary)" : "color-mix(in srgb, var(--accent-blue) 16%, transparent)"}
-                    stroke={active ? "var(--text-primary)" : "color-mix(in srgb, var(--accent-blue) 70%, transparent)"}
+                    fill={
+                      active
+                        ? "var(--text-primary)"
+                        : "color-mix(in srgb, var(--accent-blue) 22%, transparent)"
+                    }
+                    stroke={
+                      active
+                        ? "var(--text-primary)"
+                        : "color-mix(in srgb, var(--accent-blue) 70%, transparent)"
+                    }
                   />
-                  <text
-                    textAnchor="middle"
-                    dy="0.32em"
-                    style={{
-                      fontSize: 8,
-                      fontWeight: 600,
-                      pointerEvents: "none",
-                      fill: active ? "#fff" : "var(--text-primary)",
-                    }}
-                  >
-                    {c.count}
-                  </text>
-                  <title>{`${c.label} · ${c.count}`}</title>
+                  {/* A count on a single pin is noise — it's always "1". */}
+                  {c.count > 1 && (
+                    <text
+                      textAnchor="middle"
+                      dy="0.32em"
+                      style={{
+                        fontSize: 7 / zoom,
+                        fontWeight: 600,
+                        pointerEvents: "none",
+                        fill: active ? "#fff" : "var(--text-primary)",
+                      }}
+                    >
+                      {c.count}
+                    </text>
+                  )}
+                  <title>{`${c.label}${c.count > 1 ? ` · ${c.count}` : ""}`}</title>
                 </Marker>
               );
             })}
@@ -122,7 +211,7 @@ export function LibraryMapView({ entities }: { entities: Entity[] }) {
             a small minority; without this the map reads as the whole library. */}
         <div className="absolute bottom-2 left-2 text-[11px] text-ink-tertiary bg-paper/70 backdrop-blur-sm rounded px-2 py-0.5">
           {located.toLocaleString()} located {located === 1 ? "entity" : "entities"} ·{" "}
-          {clusters.length.toLocaleString()} {clusters.length === 1 ? "place" : "places"}
+          {clusters.length.toLocaleString()} {clusters.length === 1 ? "pin" : "pins"}
           {unlocated > 0 && (
             <span className="text-ink-muted">
               {" · "}

--- a/app/src/components/library/LibraryMapView.tsx
+++ b/app/src/components/library/LibraryMapView.tsx
@@ -94,14 +94,18 @@ export function LibraryMapView({ entities }: { entities: Entity[] }) {
     return acc.map((c): Cluster => {
       const [lng, lat] = invert(c.x, c.y);
       // A lone pin is one incident — name it after the entity. A cluster is a
-      // place; name it after the country its members share, if they share one.
+      // place; name it after the country its members share, and when they
+      // straddle a border, after the main one. NOT "N locations": that made
+      // every multi-country cluster of the same size share a label.
       const countries = [...new Set(c.labels.filter(Boolean))];
       const label =
         c.ids.length === 1
           ? getEntity(c.ids[0])?.title ?? countries[0] ?? "Location"
-          : countries.length === 1
-            ? countries[0]
-            : `${c.ids.length} locations`;
+          : countries.length === 0
+            ? `${c.ids.length} locations`
+            : countries.length === 1
+              ? countries[0]
+              : `${countries[0]} +${countries.length - 1}`;
       return { key: c.ids[0], label, lng, lat, count: c.ids.length, ids: c.ids };
     });
   }, [entities, language, zoom]);
@@ -166,7 +170,13 @@ export function LibraryMapView({ entities }: { entities: Entity[] }) {
               // this the markers balloon as you zoom and re-swamp the map.
               const base = c.count === 1 ? 3.5 : 4.5 + Math.min(Math.sqrt(c.count) * 1.6, 7);
               const r = base / zoom;
-              const active = selectedCluster?.ids.length === c.ids.length && selectedCluster?.label === c.label;
+              // Selected = the SAME cluster, identified by its members. Matching
+              // on (label, count) lit up every other cluster that happened to
+              // share both — three unrelated pins of 10 all went black at once.
+              const active =
+                !!selectedCluster &&
+                selectedCluster.ids.length === c.ids.length &&
+                selectedCluster.ids[0] === c.ids[0];
               return (
                 <Marker key={c.key} coordinates={[c.lng, c.lat]} onClick={() => open(c)}>
                   <circle

--- a/app/src/components/library/LibraryTimelineView.tsx
+++ b/app/src/components/library/LibraryTimelineView.tsx
@@ -144,8 +144,9 @@ const TRACK_LABEL = 26;
 const TRACK_AXIS = 44;
 const TRACK_BAR = 42;
 const TRACK_W = TRACK_AXIS + TRACK_BAR + 4;
-/** A period small enough to fan out into its members, rather than jump to. */
-const FAN_CAP = 12;
+/** A period quiet enough to read as a single dot; busier ones become a
+ *  counted ring. */
+const DOT_CAP = 12;
 
 interface TrackProps {
   buckets: TimeBucket[];
@@ -163,8 +164,6 @@ interface TrackProps {
   hovered: string | null;
   setHovered: (k: string | null) => void;
   scrollToTime: (t: number) => void;
-  selectedId: string | null;
-  onSelect: (id: string) => void;
 }
 
 function TrackedList({
@@ -290,8 +289,6 @@ function TrackedList({
     hovered,
     setHovered,
     scrollToTime,
-    selectedId,
-    onSelect,
   };
 
   return (
@@ -445,16 +442,18 @@ function EdgeCount({ dir, n, axisEnd }: { dir: "up" | "down"; n: number; axisEnd
   );
 }
 
-/** The RefMinimap idiom: a dot per small period (which fans out into its
- *  entities), a counted ring per busy one.
+/** The RefMinimap idiom: a dot per quiet period, a counted ring per busy one.
  *
- *  Clicking a node FILTERS the Library to that period — it doesn't merely scroll
- *  the list to it. Scrolling left you looking at the same 4,398 results with the
+ *  Clicking a node FILTERS the Library to that period — it doesn't scroll the
+ *  list to it. Scrolling left you looking at the same 4,398 results with the
  *  viewport moved; the point of picking a period is to be left with that period.
- *  Click it again to clear. A picked period that's small enough also fans out,
- *  so its members are one more click away. */
+ *  Click it again to clear.
+ *
+ *  No fan: once a click filters, the period's members are already the list —
+ *  fanning them onto the track as well was the same information twice, in a
+ *  cramped 40px gutter, one of them unclickable-adjacent to the other. */
 function ClusterTrack(props: TrackProps) {
-  const { buckets, extent, pos, activeKey, hovered, setHovered, selectedId, onSelect } = props;
+  const { buckets, extent, pos, activeKey, hovered, setHovered } = props;
   const range = useRange();
   const maxCount = Math.max(1, ...buckets.map((b) => b.entities.length));
 
@@ -474,9 +473,7 @@ function ClusterTrack(props: TrackProps) {
         const n = b.entities.length;
         const picked = !range.isAll && range.covers(b);
         const inRange = range.overlaps(b);
-        const small = n <= FAN_CAP;
-        // A picked period fans out — the filter and the fan are the same gesture.
-        const isOpen = picked && small;
+        const small = n <= DOT_CAP;
         const lit = picked || activeKey === b.key || hovered === b.key;
         const size = small ? (lit ? 12 : 9) : 15 + Math.min(Math.sqrt(n / maxCount) * 11, 11);
         const color = dominantColor(b.entities);
@@ -526,27 +523,12 @@ function ClusterTrack(props: TrackProps) {
                   {n > 99 ? "99+" : n}
                 </span>
               )}
-              {hovered === b.key && !isOpen && (
+              {hovered === b.key && (
                 <ChartTip>
                   {b.label} · {n.toLocaleString()}
                 </ChartTip>
               )}
             </button>
-
-            {/* Fan — the picked period's members, branching out as in RefMinimap.
-                Picking one previews that entity; it does NOT re-toggle the
-                period, so the filter survives choosing something inside it. */}
-            {isOpen && (
-              <ClusterFan
-                entities={b.entities}
-                yPct={pos(Math.max(b.start, extent.min))}
-                outer={size}
-                selectedId={selectedId}
-                hovered={hovered}
-                setHovered={setHovered}
-                onPick={(e) => onSelect(e.id)}
-              />
-            )}
           </div>
         );
       })}
@@ -631,149 +613,6 @@ function DensityTrack(props: TrackProps) {
         );
       })}
     </TrackFrame>
-  );
-}
-
-/** The expanded cluster: an SVG trunk with one branch per member, growing LEFT
- *  off the rail into the body — mirrored from the document minimap, which hangs
- *  off the right edge of the page. */
-function ClusterFan({
-  entities,
-  yPct,
-  outer,
-  selectedId,
-  hovered,
-  setHovered,
-  onPick,
-}: {
-  entities: Entity[];
-  yPct: number;
-  outer: number;
-  selectedId: string | null;
-  hovered: string | null;
-  setHovered: (id: string | null) => void;
-  onPick: (e: Entity) => void;
-}) {
-  const members = entities.slice(0, FAN_CAP);
-  const rowH = 20;
-  const dot = 9;
-  const pad = 2;
-  const branch = 14;
-  const trunkX = dot + pad + branch;
-  const stem = 10;
-  const svgW = trunkX + stem;
-  const totalH = (members.length - 1) * rowH + dot;
-  const top =
-    yPct < 25 ? outer / 2 : yPct > 75 ? -(totalH - dot) - outer / 2 : -totalH / 2 + outer / 2;
-  const midY = yPct < 25 ? dot / 2 : yPct > 75 ? totalH - dot / 2 : totalH / 2;
-
-  return (
-    <div
-      className="absolute top-1/2"
-      style={{ right: "calc(100% + 4px)", marginTop: top - outer / 2 }}
-    >
-      <svg width={svgW} height={totalH} style={{ overflow: "visible" }}>
-        {/* Stem: trunk → the rail node */}
-        <line
-          x1={trunkX}
-          y1={midY}
-          x2={svgW}
-          y2={midY}
-          stroke="var(--text-tertiary)"
-          strokeWidth={1}
-          opacity={0.4}
-        />
-        {/* Trunk */}
-        <line
-          x1={trunkX}
-          y1={dot / 2}
-          x2={trunkX}
-          y2={totalH - dot / 2}
-          stroke="var(--text-tertiary)"
-          strokeWidth={1}
-          opacity={0.4}
-        />
-        {members.map((e, i) => {
-          const cy = i * rowH + dot / 2;
-          const color = getEntityType(e.typeId)?.color ?? "#6B7280";
-          const on = selectedId === e.id || hovered === e.id;
-          const s = on ? 12 : dot;
-          return (
-            <g key={e.id}>
-              <line
-                x1={dot + pad}
-                y1={cy}
-                x2={trunkX}
-                y2={cy}
-                stroke="var(--text-tertiary)"
-                strokeWidth={1}
-                opacity={0.4}
-              />
-              <circle
-                cx={dot / 2}
-                cy={cy}
-                r={s / 2}
-                fill={color}
-                opacity={on ? 1 : 0.8}
-                tabIndex={0}
-                role="button"
-                aria-label={e.title}
-                className="cursor-pointer focus:outline-none"
-                onClick={() => onPick(e)}
-                onKeyDown={(ev) => {
-                  if (ev.key === "Enter" || ev.key === " ") {
-                    ev.preventDefault();
-                    onPick(e);
-                  }
-                }}
-                onMouseEnter={() => setHovered(e.id)}
-                onMouseLeave={() => setHovered(null)}
-              />
-              {on && (
-                <circle
-                  cx={dot / 2}
-                  cy={cy}
-                  r={s / 2 + 2.5}
-                  fill="none"
-                  stroke={color}
-                  strokeWidth={1.5}
-                  opacity={0.35}
-                />
-              )}
-            </g>
-          );
-        })}
-      </svg>
-      {/* Hover labels as HTML overlays — never SVG text inside the track */}
-      {members.map((e, i) => {
-        if (hovered !== e.id) return null;
-        return (
-          <span
-            key={`t-${e.id}`}
-            className="absolute z-50 pointer-events-none text-[10px] font-medium whitespace-nowrap rounded-md"
-            style={{
-              top: i * rowH + dot / 2,
-              right: "calc(100% + 8px)",
-              transform: "translateY(-50%)",
-              padding: "3px 7px",
-              backgroundColor: "var(--text-primary)",
-              color: "var(--bg-surface)",
-              boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
-            }}
-          >
-            {e.title}
-          </span>
-        );
-      })}
-      {entities.length > FAN_CAP && (
-        <span
-          className="absolute text-[9px] tabular-nums text-ink-muted whitespace-nowrap"
-          style={{ top: totalH + 2, right: stem }}
-        >
-          +{entities.length - FAN_CAP}
-        </span>
-      )}
-    </div>
   );
 }
 

--- a/app/src/components/library/LibraryTimelineView.tsx
+++ b/app/src/components/library/LibraryTimelineView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { CalendarDays, Layers } from "lucide-react";
 import {
@@ -183,13 +183,14 @@ function TrackedList({
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
   const [scope, setScope] = useAtom(libraryTimelineScopeAtom);
 
-  // The DENSITY track plots the date-unfiltered results, so picking a period
-  // doesn't erase the very chart you picked from — the rest stays, dimmed. The
-  // CLUSTER track only navigates, so it tracks the results as they are.
-  const source = useMemo(
-    () => (track === "density" ? sortByTime(chart) : dated),
-    [track, chart, dated],
-  );
+  // BOTH tracks plot the date-unfiltered results. Picking a period on either one
+  // filters the Library to it — if the track drew the filtered set, it would
+  // collapse to the single node you just clicked and there'd be no way back.
+  // Out-of-range periods stay on the track, dimmed.
+  const source = useMemo(() => {
+    const c = sortByTime(chart);
+    return c.length ? c : dated;
+  }, [chart, dated]);
   const fullExtent = useMemo(() => timeExtent(source) ?? timeExtent(dated)!, [source, dated]);
   const unit = useMemo(() => pickUnit(fullExtent.max - fullExtent.min), [fullExtent]);
   const groups = useMemo(() => groupByBucket(dated, unit), [dated, unit]);
@@ -442,15 +443,17 @@ function EdgeCount({ dir, n, axisEnd }: { dir: "up" | "down"; n: number; axisEnd
   );
 }
 
-/** The RefMinimap idiom: a dot per small period (fans out into its entities), a
- *  counted ring per busy one. Volume is NOT the point here — that's what the
- *  Density track and the brush strip below are for. This one navigates. */
+/** The RefMinimap idiom: a dot per small period (which fans out into its
+ *  entities), a counted ring per busy one.
+ *
+ *  Clicking a node FILTERS the Library to that period — it doesn't merely scroll
+ *  the list to it. Scrolling left you looking at the same 4,398 results with the
+ *  viewport moved; the point of picking a period is to be left with that period.
+ *  Click it again to clear. A picked period that's small enough also fans out,
+ *  so its members are one more click away. */
 function ClusterTrack(props: TrackProps) {
-  const { buckets, extent, pos, activeKey, hovered, setHovered, scrollToTime, selectedId, onSelect } =
-    props;
-  const [expanded, setExpanded] = useState<string | null>(null);
-  useEffect(() => setExpanded(null), [buckets]);
-
+  const { buckets, extent, pos, activeKey, hovered, setHovered, selectedId, onSelect } = props;
+  const range = useRange();
   const maxCount = Math.max(1, ...buckets.map((b) => b.entities.length));
 
   return (
@@ -467,9 +470,12 @@ function ClusterTrack(props: TrackProps) {
     >
       {buckets.map((b) => {
         const n = b.entities.length;
-        const isOpen = expanded === b.key;
-        const lit = isOpen || activeKey === b.key || hovered === b.key;
+        const picked = !range.isAll && range.covers(b);
+        const inRange = range.overlaps(b);
         const small = n <= FAN_CAP;
+        // A picked period fans out — the filter and the fan are the same gesture.
+        const isOpen = picked && small;
+        const lit = picked || activeKey === b.key || hovered === b.key;
         const size = small ? (lit ? 12 : 9) : 15 + Math.min(Math.sqrt(n / maxCount) * 11, 11);
         const color = dominantColor(b.entities);
 
@@ -478,15 +484,17 @@ function ClusterTrack(props: TrackProps) {
             key={b.key}
             // Anchored so the node's centre lands ON the axis line.
             className="absolute -translate-y-1/2 translate-x-1/2"
-            style={{ top: `${pos(Math.max(b.start, extent.min))}%`, insetInlineEnd: TRACK_AXIS }}
+            style={{
+              top: `${pos(Math.max(b.start, extent.min))}%`,
+              insetInlineEnd: TRACK_AXIS,
+              // Out-of-range periods recede but stay: the way back is the track.
+              opacity: inRange ? 1 : 0.28,
+            }}
           >
             <button
               aria-label={`${b.label} — ${n.toLocaleString()} ${n === 1 ? "entity" : "entities"}`}
-              aria-expanded={small ? isOpen : undefined}
-              onClick={() => {
-                scrollToTime(b.start);
-                if (small) setExpanded(isOpen ? null : b.key);
-              }}
+              aria-pressed={picked}
+              onClick={() => range.toggle(b)}
               onMouseEnter={() => setHovered(b.key)}
               onMouseLeave={() => setHovered(null)}
               className="flex items-center justify-center rounded-full transition-all cursor-pointer
@@ -523,8 +531,10 @@ function ClusterTrack(props: TrackProps) {
               )}
             </button>
 
-            {/* Fan — the period's members branching out, as in RefMinimap */}
-            {isOpen && small && (
+            {/* Fan — the picked period's members, branching out as in RefMinimap.
+                Picking one previews that entity; it does NOT re-toggle the
+                period, so the filter survives choosing something inside it. */}
+            {isOpen && (
               <ClusterFan
                 entities={b.entities}
                 yPct={pos(Math.max(b.start, extent.min))}
@@ -532,10 +542,7 @@ function ClusterTrack(props: TrackProps) {
                 selectedId={selectedId}
                 hovered={hovered}
                 setHovered={setHovered}
-                onPick={(e) => {
-                  onSelect(e.id);
-                  scrollToTime(entityTime(e)!);
-                }}
+                onPick={(e) => onSelect(e.id)}
               />
             )}
           </div>

--- a/app/src/components/library/LibraryTimelineView.tsx
+++ b/app/src/components/library/LibraryTimelineView.tsx
@@ -297,7 +297,9 @@ function TrackedList({
   return (
     <div className="flex h-full min-h-0 gap-3">
       {/* Period-grouped body */}
-      <div ref={scrollRef} onScroll={onScroll} className="flex-1 min-w-0 overflow-auto pe-1">
+      {/* no-scrollbar: the OS scrollbar landed between the list and the track,
+          reading as a second axis. The track is the scroll indicator here. */}
+      <div ref={scrollRef} onScroll={onScroll} className="flex-1 min-w-0 overflow-auto no-scrollbar pe-1">
         {groups.map((g) => {
           const open = openGroups[g.key];
           const shown = open ? g.entities : g.entities.slice(0, GROUP_CAP);
@@ -917,7 +919,7 @@ function SpineLayout({ dated, selectedId, onSelect }: LayoutProps) {
   }, [plotted, extent]);
 
   return (
-    <div className="h-full overflow-auto">
+    <div className="h-full overflow-auto no-scrollbar">
       <div className="relative" style={{ height }}>
         {/* Axis — right rail */}
         <div
@@ -1081,7 +1083,7 @@ function LanesLayout({ laneChart }: LayoutProps) {
   const colW = 26;
 
   return (
-    <div className="h-full overflow-auto">
+    <div className="h-full overflow-auto no-scrollbar">
       <div dir="ltr" className="inline-block min-w-full">
         {/* Column heads */}
         <div className="flex sticky top-0 z-10 bg-warm pb-1">

--- a/app/src/components/library/LibraryTimelineView.tsx
+++ b/app/src/components/library/LibraryTimelineView.tsx
@@ -130,13 +130,20 @@ function useRange() {
  *                    FILTERS the Library to that period.
  * ------------------------------------------------------------------ */
 
-/** Reserved for the year marks at the rail's outer edge. */
-const RAIL_LABEL = 26;
-/** Longest a density bar can grow, inward from the axis. */
-const RAIL_BAR = 46;
-/** Where the cluster track's axis sits — far enough in that a counted ring can
- *  straddle it without landing on the year marks. */
-const CLUSTER_AXIS = 40;
+/* ONE track geometry, shared by Rail, Density and Spine. The axis lands at the
+ * same x in every layout, so switching between them doesn't slide the timeline
+ * across the pane. All three measure from the pane's inline-end edge:
+ *
+ *   |<-- TRACK_BAR -->|<- TRACK_AXIS ->|
+ *   [ bars / leaders ]|                | axis line
+ *                     |     marks      | TRACK_LABEL
+ *
+ * TRACK_AXIS has to clear TRACK_LABEL by more than a counted ring's radius —
+ * the cluster nodes straddle the axis, the density bars only grow inward. */
+const TRACK_LABEL = 26;
+const TRACK_AXIS = 44;
+const TRACK_BAR = 42;
+const TRACK_W = TRACK_AXIS + TRACK_BAR + 4;
 /** A period small enough to fan out into its members, rather than jump to. */
 const FAN_CAP = 12;
 
@@ -409,7 +416,7 @@ function TrackFrame({
           <span
             key={`l-${m.label}`}
             className="absolute text-[9px] tabular-nums text-ink-muted -translate-y-1/2 pointer-events-none text-start"
-            style={{ top: `${m.yPct}%`, insetInlineEnd: 0, width: RAIL_LABEL }}
+            style={{ top: `${m.yPct}%`, insetInlineEnd: 0, width: TRACK_LABEL }}
           >
             {m.label}
           </span>
@@ -448,8 +455,8 @@ function ClusterTrack(props: TrackProps) {
 
   return (
     <TrackFrame
-      width={RAIL_BAR + RAIL_LABEL + 8}
-      axisEnd={CLUSTER_AXIS}
+      width={TRACK_W}
+      axisEnd={TRACK_AXIS}
       label="Timeline — periods"
       scope={props.scope}
       setScope={props.setScope}
@@ -471,7 +478,7 @@ function ClusterTrack(props: TrackProps) {
             key={b.key}
             // Anchored so the node's centre lands ON the axis line.
             className="absolute -translate-y-1/2 translate-x-1/2"
-            style={{ top: `${pos(Math.max(b.start, extent.min))}%`, insetInlineEnd: CLUSTER_AXIS }}
+            style={{ top: `${pos(Math.max(b.start, extent.min))}%`, insetInlineEnd: TRACK_AXIS }}
           >
             <button
               aria-label={`${b.label} — ${n.toLocaleString()} ${n === 1 ? "entity" : "entities"}`}
@@ -553,8 +560,8 @@ function DensityTrack(props: TrackProps) {
 
   return (
     <TrackFrame
-      width={RAIL_BAR + RAIL_LABEL + 8}
-      axisEnd={RAIL_LABEL}
+      width={TRACK_W}
+      axisEnd={TRACK_AXIS}
       label="Timeline — volume by period"
       scope={props.scope}
       setScope={props.setScope}
@@ -568,7 +575,7 @@ function DensityTrack(props: TrackProps) {
         const lit = range.overlaps(b);
         const picked = !range.isAll && range.covers(b);
         const isHov = hovered === b.key;
-        const w = 4 + Math.sqrt(n / maxCount) * (RAIL_BAR - 4);
+        const w = 4 + Math.sqrt(n / maxCount) * (TRACK_BAR - 4);
         // Bars are as tall as their period is long — a period that is 1/40th of
         // the corpus occupies 1/40th of the rail. Gaps in time stay gaps.
         const top = pos(Math.max(b.start, extent.min));
@@ -591,11 +598,11 @@ function DensityTrack(props: TrackProps) {
             className="absolute cursor-pointer transition-[width,opacity] duration-150
               focus:outline-none focus-visible:ring-2 focus-visible:ring-carbon/40"
             style={{
-              insetInlineEnd: RAIL_LABEL + 1,
+              insetInlineEnd: TRACK_AXIS + 1,
               top: `${top}%`,
               height: `calc(${h}% - 1px)`,
               minHeight: 3,
-              width: isHov || picked ? Math.min(RAIL_BAR, w + 4) : w,
+              width: isHov || picked ? Math.min(TRACK_BAR, w + 4) : w,
               opacity: lit ? (isHov || picked || activeKey === b.key ? 1 : 0.65) : 0.16,
             }}
           >
@@ -794,7 +801,9 @@ const PX_PER_YEAR = 190;
 const EVENT_H = 22;
 /** The axis lives on the right, like the rail and the document's ref minimap.
  *  This is the gutter kept for its year marks. */
-const AXIS_GUTTER = 58;
+/** The spine's axis sits at the SAME inset as the Rail/Density track, so the
+ *  timeline doesn't slide across the pane when you switch layout. */
+const AXIS_GUTTER = TRACK_AXIS;
 const LEADER_W = 22;
 /** The longest stretch of nothing the axis will draw at true scale before it
  *  elides — see the break markers. */
@@ -876,7 +885,11 @@ function SpineLayout({ dated, selectedId, onSelect }: LayoutProps) {
         m = new Date(Date.UTC(m.getUTCFullYear(), m.getUTCMonth() + step, 1))
       ) {
         const pos = at(m.getTime());
-        if (pos >= 0) years.push({ label: bucketOf(m.getTime(), "month").label, y: pos });
+        // Compact: "Jan 2009" doesn't fit the shared 26px label column. January
+        // carries the year, every other month is just its name.
+        const full = bucketOf(m.getTime(), "month").label;
+        const label = m.getUTCMonth() === 0 ? String(m.getUTCFullYear()) : full.slice(0, 3);
+        if (pos >= 0) years.push({ label, y: pos });
       }
     } else {
       const y0 = d0.getUTCFullYear();
@@ -890,10 +903,8 @@ function SpineLayout({ dated, selectedId, onSelect }: LayoutProps) {
     // The first mark is often clipped (a range starting 17 Jan has no 1 Jan
     // tick above it) — anchor the top of the axis explicitly.
     if (!years.length || years[0].y > 14) {
-      years.unshift({
-        label: bucketOf(extent.min, spanYears < 2.5 ? "month" : "year").label,
-        y: 6,
-      });
+      const anchor = bucketOf(extent.min, spanYears < 2.5 ? "month" : "year").label;
+      years.unshift({ label: spanYears < 2.5 ? anchor.slice(0, 3) : anchor, y: 6 });
     }
     return { rows, height, years, gaps };
   }, [plotted, extent]);
@@ -917,7 +928,10 @@ function SpineLayout({ dated, selectedId, onSelect }: LayoutProps) {
             style={{ top: y.y, insetInlineEnd: 0 }}
           >
             <span className="w-1.5 h-px" style={{ backgroundColor: "var(--border-primary)" }} />
-            <span className="w-12 text-[9px] tabular-nums text-ink-tertiary whitespace-nowrap">
+            <span
+              className="text-[9px] tabular-nums text-ink-muted whitespace-nowrap"
+              style={{ width: TRACK_LABEL }}
+            >
               {y.label}
             </span>
           </div>

--- a/app/src/components/library/LibraryTimelineView.tsx
+++ b/app/src/components/library/LibraryTimelineView.tsx
@@ -1,0 +1,1165 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { CalendarDays, Layers } from "lucide-react";
+import {
+  libraryTimelineLayoutAtom,
+  libraryTimelineScopeAtom,
+  libraryDateFromAtom,
+  libraryDateToAtom,
+  libraryTypeFiltersAtom,
+  type TimelineLayout,
+  type TimelineScope,
+} from "../../atoms/library";
+import { getEntityType, type Entity } from "../../data/entities";
+import {
+  bucketOf,
+  colorSpread,
+  dominantColor,
+  entityTime,
+  formatDay,
+  groupByBucket,
+  pickUnit,
+  stackByType,
+  timeExtent,
+  toISODate,
+  typeOrder,
+  type TimeBucket,
+} from "../../utils/timeline";
+import { BucketBreakdown, ChartTip } from "./BucketBreakdown";
+import { EntityCard } from "./EntityCard";
+
+/** How many entities the proportional spine plots before it stops — the corpus
+ *  runs to thousands and a row each would be a 200k-pixel column. Narrow the
+ *  range to see the rest. */
+const SPINE_CAP = 400;
+/** Entities revealed per period group in the rail body before "+N more". */
+const GROUP_CAP = 20;
+
+interface Props {
+  /** The results — every facet applied, date included. The BODIES render this. */
+  entities: Entity[];
+  /** Results with every facet applied EXCEPT the date range. The TRACKS render
+   *  this, so picking a period doesn't collapse the very chart you picked from:
+   *  out-of-range volume stays visible, just dimmed. */
+  chart: Entity[];
+  /** As `chart`, minus the template facet too — the Lanes grid keeps all its
+   *  lanes after a drill-in, instead of shrinking to the one you clicked. */
+  laneChart: Entity[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onView: (id: string) => void;
+  countByEntity: Map<string, number>;
+}
+
+export function LibraryTimelineView(props: Props) {
+  const layout = useAtomValue(libraryTimelineLayoutAtom);
+  const { entities } = props;
+
+  const dated = useMemo(() => sortByTime(entities), [entities]);
+  const undated = entities.length - dated.length;
+
+  if (!dated.length) {
+    return (
+      <div className="flex items-center justify-center h-40 text-sm text-ink-muted">
+        {entities.length
+          ? `None of these ${entities.length.toLocaleString()} entities carry a date.`
+          : "No entities match your filters."}
+      </div>
+    );
+  }
+
+  const body =
+    layout === "spine" ? (
+      <SpineLayout {...props} dated={dated} />
+    ) : layout === "lanes" ? (
+      <LanesLayout {...props} dated={dated} />
+    ) : (
+      <TrackedList {...props} dated={dated} track={layout === "density" ? "density" : "clusters"} />
+    );
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex-1 min-h-0">{body}</div>
+      {undated > 0 && (
+        <div className="shrink-0 pt-2 text-[11px] text-ink-muted">
+          {undated.toLocaleString()} undated {undated === 1 ? "entity" : "entities"} not plotted.
+        </div>
+      )}
+    </div>
+  );
+}
+
+const sortByTime = (list: Entity[]) =>
+  list.filter((e) => entityTime(e) !== null).sort((a, b) => entityTime(a)! - entityTime(b)!);
+
+interface LayoutProps extends Props {
+  dated: Entity[];
+}
+
+/** The active date range as ms, or null on either side. */
+function useRange() {
+  const [dateFrom, setDateFrom] = useAtom(libraryDateFromAtom);
+  const [dateTo, setDateTo] = useAtom(libraryDateToAtom);
+  const from = dateFrom ? Date.parse(dateFrom) : null;
+  const to = dateTo ? Date.parse(dateTo) + 86_399_999 : null;
+  const covers = (b: { start: number; end: number }) =>
+    (from === null || b.start >= from) && (to === null || b.end - 1 <= to);
+  const overlaps = (b: { start: number; end: number }) =>
+    (from === null || b.end > from) && (to === null || b.start <= to);
+  /** Click a period → the range IS that period. Click it again → back to all. */
+  const toggle = (b: TimeBucket) => {
+    if (covers(b) && (from !== null || to !== null)) {
+      setDateFrom("");
+      setDateTo("");
+    } else {
+      setDateFrom(toISODate(b.start));
+      setDateTo(toISODate(b.end - 86_400_000));
+    }
+  };
+  return { from, to, covers, overlaps, toggle, isAll: from === null && to === null };
+}
+
+/* ------------------------------------------------------------------ *
+ * 1 & 2 — RAIL and DENSITY. Same shell: a period-grouped list with a
+ *     vertical time track on the right, where the document's reference
+ *     minimap sits. Two tracks swap into it:
+ *       · clusters — dots and counted clusters that FAN OUT into their
+ *                    members (RefMinimap, straight across). Navigation:
+ *                    clicking picks an entity, it never filters.
+ *       · density  — the same periods as volume bars. Clicking a bar
+ *                    FILTERS the Library to that period.
+ * ------------------------------------------------------------------ */
+
+/** Reserved for the year marks at the rail's outer edge. */
+const RAIL_LABEL = 26;
+/** Longest a density bar can grow, inward from the axis. */
+const RAIL_BAR = 46;
+/** Where the cluster track's axis sits — far enough in that a counted ring can
+ *  straddle it without landing on the year marks. */
+const CLUSTER_AXIS = 40;
+/** A period small enough to fan out into its members, rather than jump to. */
+const FAN_CAP = 12;
+
+interface TrackProps {
+  buckets: TimeBucket[];
+  extent: { min: number; max: number };
+  /** ms → % down the plotting area. Owned by the shell, because the year scope
+   *  insets the plot to make room for the ↑/↓ edge counts. */
+  pos: (ms: number) => number;
+  marks: { label: string; yPct: number }[];
+  scope: TimelineScope;
+  setScope: (s: TimelineScope) => void;
+  focusYear: number;
+  before: number;
+  after: number;
+  activeKey: string | null;
+  hovered: string | null;
+  setHovered: (k: string | null) => void;
+  scrollToTime: (t: number) => void;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+function TrackedList({
+  dated,
+  chart,
+  selectedId,
+  onSelect,
+  onView,
+  countByEntity,
+  track,
+}: LayoutProps & { track: "clusters" | "density" }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const groupRefs = useRef(new Map<string, HTMLDivElement>());
+  const [hovered, setHovered] = useState<string | null>(null);
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
+  const [scope, setScope] = useAtom(libraryTimelineScopeAtom);
+
+  // The DENSITY track plots the date-unfiltered results, so picking a period
+  // doesn't erase the very chart you picked from — the rest stays, dimmed. The
+  // CLUSTER track only navigates, so it tracks the results as they are.
+  const source = useMemo(
+    () => (track === "density" ? sortByTime(chart) : dated),
+    [track, chart, dated],
+  );
+  const fullExtent = useMemo(() => timeExtent(source) ?? timeExtent(dated)!, [source, dated]);
+  const unit = useMemo(() => pickUnit(fullExtent.max - fullExtent.min), [fullExtent]);
+  const groups = useMemo(() => groupByBucket(dated, unit), [dated, unit]);
+
+  // The year the reader is in — the period at the top of the list, else the first.
+  const focusYear = useMemo(() => {
+    const g = groups.find((x) => x.key === activeKey) ?? groups[0];
+    return new Date(g?.start ?? fullExtent.min).getUTCFullYear();
+  }, [groups, activeKey, fullExtent]);
+
+  // Scope: the whole span, or one year at month granularity — the document
+  // minimap's whole-document / this-page toggle, on time.
+  const { extent, trackBuckets, before, after, marks, pos } = useMemo(() => {
+    const isYear = scope === "year";
+    const extent = isYear
+      ? { min: Date.UTC(focusYear, 0, 1), max: Date.UTC(focusYear + 1, 0, 1) - 1 }
+      : fullExtent;
+    const inRange = isYear
+      ? source.filter((e) => {
+          const t = entityTime(e)!;
+          return t >= extent.min && t <= extent.max;
+        })
+      : source;
+    const trackBuckets = groupByBucket(inRange.length ? inRange : [], isYear ? "month" : unit);
+
+    let before = 0;
+    let after = 0;
+    if (isYear)
+      for (const e of source) {
+        const t = entityTime(e)!;
+        if (t < extent.min) before++;
+        else if (t > extent.max) after++;
+      }
+
+    // Year scope insets the plot so the ↑/↓ edge counts have room.
+    const top = isYear ? 12 : 3;
+    const height = isYear ? 76 : 94;
+    const span = Math.max(1, extent.max - extent.min);
+    const pos = (ms: number) =>
+      top + ((Math.min(Math.max(ms, extent.min), extent.max) - extent.min) / span) * height;
+
+    const marks: { label: string; yPct: number }[] = [];
+    if (isYear) {
+      for (let m = 0; m < 12; m += 2)
+        marks.push({
+          label: bucketOf(Date.UTC(focusYear, m, 1), "month").label.slice(0, 3),
+          yPct: pos(Date.UTC(focusYear, m, 1)),
+        });
+    } else {
+      const seen = new Set<number>();
+      const all: { label: string; yPct: number }[] = [];
+      for (const b of trackBuckets) {
+        const y = new Date(b.start).getUTCFullYear();
+        if (seen.has(y)) continue;
+        seen.add(y);
+        all.push({ label: String(y), yPct: pos(Math.max(b.start, extent.min)) });
+      }
+      const every = Math.max(1, Math.ceil(all.length / 9));
+      marks.push(...all.filter((_, i) => i % every === 0));
+    }
+    return { extent, trackBuckets, before, after, marks, pos };
+  }, [scope, focusYear, fullExtent, source, unit]);
+
+  const scrollToTime = useCallback(
+    (t: number) => {
+      const el = groupRefs.current.get(bucketOf(t, unit).key);
+      const pane = scrollRef.current;
+      if (el && pane) pane.scrollTo({ top: el.offsetTop - 8, behavior: "smooth" });
+    },
+    [unit],
+  );
+
+  // Which period is at the top of the viewport — lights its node.
+  const onScroll = () => {
+    const pane = scrollRef.current;
+    if (!pane) return;
+    const y = pane.scrollTop + 16;
+    let hit: string | null = null;
+    for (const g of groups) {
+      const el = groupRefs.current.get(g.key);
+      if (el && el.offsetTop <= y) hit = g.key;
+    }
+    setActiveKey(hit);
+  };
+
+  const trackProps: TrackProps = {
+    buckets: trackBuckets,
+    extent,
+    pos,
+    marks,
+    scope,
+    setScope,
+    focusYear,
+    before,
+    after,
+    activeKey,
+    hovered,
+    setHovered,
+    scrollToTime,
+    selectedId,
+    onSelect,
+  };
+
+  return (
+    <div className="flex h-full min-h-0 gap-3">
+      {/* Period-grouped body */}
+      <div ref={scrollRef} onScroll={onScroll} className="flex-1 min-w-0 overflow-auto pe-1">
+        {groups.map((g) => {
+          const open = openGroups[g.key];
+          const shown = open ? g.entities : g.entities.slice(0, GROUP_CAP);
+          return (
+            <div
+              key={g.key}
+              ref={(el) => {
+                if (el) groupRefs.current.set(g.key, el);
+                else groupRefs.current.delete(g.key);
+              }}
+              className="pb-4"
+            >
+              <PeriodHeader bucket={g} active={activeKey === g.key} />
+              <div className="space-y-1.5 pt-1.5">
+                {shown.map((e) => (
+                  <EntityCard
+                    key={e.id}
+                    entity={e}
+                    layout="list"
+                    selected={selectedId === e.id}
+                    connections={countByEntity.get(e.id) ?? 0}
+                    onSelect={onSelect}
+                    onView={onView}
+                  />
+                ))}
+              </div>
+              {g.entities.length > GROUP_CAP && (
+                <button
+                  onClick={() => setOpenGroups((s) => ({ ...s, [g.key]: !s[g.key] }))}
+                  className="mt-1.5 px-2 py-1 text-[11px] font-medium text-ink-tertiary hover:text-ink bg-warm hover:bg-parchment rounded-md transition-colors cursor-pointer"
+                >
+                  {open
+                    ? "Show less"
+                    : `+${(g.entities.length - GROUP_CAP).toLocaleString()} more in ${g.label}`}
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {track === "density" ? <DensityTrack {...trackProps} /> : <ClusterTrack {...trackProps} />}
+    </div>
+  );
+}
+
+/** Shared chrome for both tracks: the scope toggle, the axis, the ↑/↓ counts for
+ *  what the year scope leaves off, and the thinned marks. Straight off
+ *  RefMinimap's whole-document / this-page rail. */
+function TrackFrame({
+  width,
+  axisEnd,
+  label,
+  scope,
+  setScope,
+  focusYear,
+  before,
+  after,
+  marks,
+  children,
+}: {
+  width: number;
+  /** Distance from the rail's outer edge to the axis line. The cluster track
+   *  centres its nodes ON the axis, so it needs room on both sides; the density
+   *  track only grows inward, so its axis can hug the year marks. */
+  axisEnd: number;
+  label: string;
+  scope: TimelineScope;
+  setScope: (s: TimelineScope) => void;
+  focusYear: number;
+  before: number;
+  after: number;
+  marks: { label: string; yPct: number }[];
+  children: React.ReactNode;
+}) {
+  const isYear = scope === "year";
+  return (
+    <div className="relative shrink-0 flex flex-col" style={{ width }} role="group" aria-label={label}>
+      {/* Scope toggle — centred ON the axis, like the minimap's mode button.
+          Anchor the inline-end edge to the axis, then push back by half the
+          element's own width: `insetInlineEnd` + a NEGATIVE translate would
+          double-count and land everything off-axis. */}
+      <div className="relative h-6 shrink-0">
+        <button
+          onClick={() => setScope(isYear ? "all" : "year")}
+          aria-pressed={isYear}
+          title={isYear ? `${focusYear}` : "Whole timeline"}
+          aria-label={
+            isYear
+              ? `Showing ${focusYear} — switch to the whole timeline`
+              : "Showing the whole timeline — switch to this year"
+          }
+          className="absolute top-0 flex items-center justify-center rounded-md transition-colors cursor-pointer
+            text-ink-tertiary hover:bg-warm hover:text-ink-secondary translate-x-1/2
+            focus:outline-none focus-visible:ring-2 focus-visible:ring-carbon/40"
+          style={{ width: 22, height: 22, insetInlineEnd: axisEnd }}
+        >
+          {isYear ? <CalendarDays size={12} /> : <Layers size={12} />}
+        </button>
+      </div>
+
+      <div className="relative flex-1 min-h-0">
+        <div
+          className="absolute top-0 bottom-0"
+          style={{ insetInlineEnd: axisEnd, width: 1, backgroundColor: "var(--border-primary)" }}
+        />
+
+        {/* What the year scope leaves off, above and below */}
+        {isYear && before > 0 && <EdgeCount dir="up" n={before} axisEnd={axisEnd} />}
+        {isYear && after > 0 && <EdgeCount dir="down" n={after} axisEnd={axisEnd} />}
+
+        {children}
+
+        {/* One label column: fixed width so "1986" and "Jan" share a left edge
+            instead of each hanging off its own text width. */}
+        {marks.map((m) => (
+          <span
+            key={`l-${m.label}`}
+            className="absolute text-[9px] tabular-nums text-ink-muted -translate-y-1/2 pointer-events-none text-start"
+            style={{ top: `${m.yPct}%`, insetInlineEnd: 0, width: RAIL_LABEL }}
+          >
+            {m.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EdgeCount({ dir, n, axisEnd }: { dir: "up" | "down"; n: number; axisEnd: number }) {
+  return (
+    <span
+      className="absolute text-[10px] font-medium tabular-nums leading-none translate-x-1/2 rounded-[3px] px-1 py-0.5 pointer-events-none whitespace-nowrap"
+      style={{
+        insetInlineEnd: axisEnd,
+        [dir === "up" ? "top" : "bottom"]: 0,
+        color: "var(--text-tertiary)",
+        backgroundColor: "var(--bg-warm)",
+      }}
+    >
+      {dir === "up" ? "↑" : "↓"} {n.toLocaleString()}
+    </span>
+  );
+}
+
+/** The RefMinimap idiom: a dot per small period (fans out into its entities), a
+ *  counted ring per busy one. Volume is NOT the point here — that's what the
+ *  Density track and the brush strip below are for. This one navigates. */
+function ClusterTrack(props: TrackProps) {
+  const { buckets, extent, pos, activeKey, hovered, setHovered, scrollToTime, selectedId, onSelect } =
+    props;
+  const [expanded, setExpanded] = useState<string | null>(null);
+  useEffect(() => setExpanded(null), [buckets]);
+
+  const maxCount = Math.max(1, ...buckets.map((b) => b.entities.length));
+
+  return (
+    <TrackFrame
+      width={RAIL_BAR + RAIL_LABEL + 8}
+      axisEnd={CLUSTER_AXIS}
+      label="Timeline — periods"
+      scope={props.scope}
+      setScope={props.setScope}
+      focusYear={props.focusYear}
+      before={props.before}
+      after={props.after}
+      marks={props.marks}
+    >
+      {buckets.map((b) => {
+        const n = b.entities.length;
+        const isOpen = expanded === b.key;
+        const lit = isOpen || activeKey === b.key || hovered === b.key;
+        const small = n <= FAN_CAP;
+        const size = small ? (lit ? 12 : 9) : 15 + Math.min(Math.sqrt(n / maxCount) * 11, 11);
+        const color = dominantColor(b.entities);
+
+        return (
+          <div
+            key={b.key}
+            // Anchored so the node's centre lands ON the axis line.
+            className="absolute -translate-y-1/2 translate-x-1/2"
+            style={{ top: `${pos(Math.max(b.start, extent.min))}%`, insetInlineEnd: CLUSTER_AXIS }}
+          >
+            <button
+              aria-label={`${b.label} — ${n.toLocaleString()} ${n === 1 ? "entity" : "entities"}`}
+              aria-expanded={small ? isOpen : undefined}
+              onClick={() => {
+                scrollToTime(b.start);
+                if (small) setExpanded(isOpen ? null : b.key);
+              }}
+              onMouseEnter={() => setHovered(b.key)}
+              onMouseLeave={() => setHovered(null)}
+              className="flex items-center justify-center rounded-full transition-all cursor-pointer
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-carbon/40"
+              style={
+                small
+                  ? {
+                      width: size,
+                      height: size,
+                      backgroundColor: color,
+                      opacity: lit ? 1 : 0.75,
+                      boxShadow: lit ? `0 0 0 3px ${color}33` : "none",
+                    }
+                  : {
+                      width: size,
+                      height: size,
+                      border: `1.5px solid ${lit ? "var(--text-secondary)" : "var(--border-soft)"}`,
+                      backgroundColor: lit ? "var(--bg-muted)" : "var(--bg-surface)",
+                    }
+              }
+            >
+              {!small && (
+                <span
+                  className="text-[9px] font-bold leading-none tabular-nums"
+                  style={{ color: lit ? "var(--text-primary)" : "var(--text-tertiary)" }}
+                >
+                  {n > 99 ? "99+" : n}
+                </span>
+              )}
+              {hovered === b.key && !isOpen && (
+                <ChartTip>
+                  {b.label} · {n.toLocaleString()}
+                </ChartTip>
+              )}
+            </button>
+
+            {/* Fan — the period's members branching out, as in RefMinimap */}
+            {isOpen && small && (
+              <ClusterFan
+                entities={b.entities}
+                yPct={pos(Math.max(b.start, extent.min))}
+                outer={size}
+                selectedId={selectedId}
+                hovered={hovered}
+                setHovered={setHovered}
+                onPick={(e) => {
+                  onSelect(e.id);
+                  scrollToTime(entityTime(e)!);
+                }}
+              />
+            )}
+          </div>
+        );
+      })}
+    </TrackFrame>
+  );
+}
+
+/** The same periods as volume bars — proportional in time, length = count,
+ *  STACKED by template. The rail is where composition is read: a bar is short,
+ *  but the segments are stable in order down the whole track, so you can see the
+ *  corpus diversify. The wide brush strip below carries the volume SHAPE instead.
+ *
+ *  Clicking a period filters the Library to it (click again to clear). */
+function DensityTrack(props: TrackProps) {
+  const { buckets, extent, pos, activeKey, hovered, setHovered, scrollToTime } = props;
+  const range = useRange();
+  const maxCount = Math.max(1, ...buckets.map((b) => b.entities.length));
+  // ONE segment order for the whole track, or the stacks wouldn't be comparable.
+  const order = useMemo(() => typeOrder(buckets.flatMap((b) => b.entities)), [buckets]);
+
+  return (
+    <TrackFrame
+      width={RAIL_BAR + RAIL_LABEL + 8}
+      axisEnd={RAIL_LABEL}
+      label="Timeline — volume by period"
+      scope={props.scope}
+      setScope={props.setScope}
+      focusYear={props.focusYear}
+      before={props.before}
+      after={props.after}
+      marks={props.marks}
+    >
+      {buckets.map((b) => {
+        const n = b.entities.length;
+        const lit = range.overlaps(b);
+        const picked = !range.isAll && range.covers(b);
+        const isHov = hovered === b.key;
+        const w = 4 + Math.sqrt(n / maxCount) * (RAIL_BAR - 4);
+        // Bars are as tall as their period is long — a period that is 1/40th of
+        // the corpus occupies 1/40th of the rail. Gaps in time stay gaps.
+        const top = pos(Math.max(b.start, extent.min));
+        const h = Math.max(pos(Math.min(b.end, extent.max)) - top, 0);
+        const slices = stackByType(b.entities, order);
+
+        return (
+          <button
+            key={b.key}
+            aria-label={`${b.label} — ${n.toLocaleString()} ${n === 1 ? "entity" : "entities"}: ${slices
+              .map((s) => `${s.n} ${s.name}`)
+              .join(", ")}`}
+            aria-pressed={picked}
+            onClick={() => {
+              range.toggle(b);
+              scrollToTime(b.start);
+            }}
+            onMouseEnter={() => setHovered(b.key)}
+            onMouseLeave={() => setHovered(null)}
+            className="absolute cursor-pointer transition-[width,opacity] duration-150
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-carbon/40"
+            style={{
+              insetInlineEnd: RAIL_LABEL + 1,
+              top: `${top}%`,
+              height: `calc(${h}% - 1px)`,
+              minHeight: 3,
+              width: isHov || picked ? Math.min(RAIL_BAR, w + 4) : w,
+              opacity: lit ? (isHov || picked || activeKey === b.key ? 1 : 0.65) : 0.16,
+            }}
+          >
+            {/* Reversed so the biggest slice hugs the axis — the axis is the
+                baseline this bar grows from. */}
+            <span className="flex flex-row-reverse w-full h-full overflow-hidden rounded-s-[2px]">
+              {slices.map((s) => (
+                <span key={s.typeId} style={{ width: `${s.frac * 100}%`, backgroundColor: s.color }} />
+              ))}
+            </span>
+            {isHov && (
+              <ChartTip>
+                <BucketBreakdown label={b.label} total={n} slices={slices} />
+              </ChartTip>
+            )}
+          </button>
+        );
+      })}
+    </TrackFrame>
+  );
+}
+
+/** The expanded cluster: an SVG trunk with one branch per member, growing LEFT
+ *  off the rail into the body — mirrored from the document minimap, which hangs
+ *  off the right edge of the page. */
+function ClusterFan({
+  entities,
+  yPct,
+  outer,
+  selectedId,
+  hovered,
+  setHovered,
+  onPick,
+}: {
+  entities: Entity[];
+  yPct: number;
+  outer: number;
+  selectedId: string | null;
+  hovered: string | null;
+  setHovered: (id: string | null) => void;
+  onPick: (e: Entity) => void;
+}) {
+  const members = entities.slice(0, FAN_CAP);
+  const rowH = 20;
+  const dot = 9;
+  const pad = 2;
+  const branch = 14;
+  const trunkX = dot + pad + branch;
+  const stem = 10;
+  const svgW = trunkX + stem;
+  const totalH = (members.length - 1) * rowH + dot;
+  const top =
+    yPct < 25 ? outer / 2 : yPct > 75 ? -(totalH - dot) - outer / 2 : -totalH / 2 + outer / 2;
+  const midY = yPct < 25 ? dot / 2 : yPct > 75 ? totalH - dot / 2 : totalH / 2;
+
+  return (
+    <div
+      className="absolute top-1/2"
+      style={{ right: "calc(100% + 4px)", marginTop: top - outer / 2 }}
+    >
+      <svg width={svgW} height={totalH} style={{ overflow: "visible" }}>
+        {/* Stem: trunk → the rail node */}
+        <line
+          x1={trunkX}
+          y1={midY}
+          x2={svgW}
+          y2={midY}
+          stroke="var(--text-tertiary)"
+          strokeWidth={1}
+          opacity={0.4}
+        />
+        {/* Trunk */}
+        <line
+          x1={trunkX}
+          y1={dot / 2}
+          x2={trunkX}
+          y2={totalH - dot / 2}
+          stroke="var(--text-tertiary)"
+          strokeWidth={1}
+          opacity={0.4}
+        />
+        {members.map((e, i) => {
+          const cy = i * rowH + dot / 2;
+          const color = getEntityType(e.typeId)?.color ?? "#6B7280";
+          const on = selectedId === e.id || hovered === e.id;
+          const s = on ? 12 : dot;
+          return (
+            <g key={e.id}>
+              <line
+                x1={dot + pad}
+                y1={cy}
+                x2={trunkX}
+                y2={cy}
+                stroke="var(--text-tertiary)"
+                strokeWidth={1}
+                opacity={0.4}
+              />
+              <circle
+                cx={dot / 2}
+                cy={cy}
+                r={s / 2}
+                fill={color}
+                opacity={on ? 1 : 0.8}
+                tabIndex={0}
+                role="button"
+                aria-label={e.title}
+                className="cursor-pointer focus:outline-none"
+                onClick={() => onPick(e)}
+                onKeyDown={(ev) => {
+                  if (ev.key === "Enter" || ev.key === " ") {
+                    ev.preventDefault();
+                    onPick(e);
+                  }
+                }}
+                onMouseEnter={() => setHovered(e.id)}
+                onMouseLeave={() => setHovered(null)}
+              />
+              {on && (
+                <circle
+                  cx={dot / 2}
+                  cy={cy}
+                  r={s / 2 + 2.5}
+                  fill="none"
+                  stroke={color}
+                  strokeWidth={1.5}
+                  opacity={0.35}
+                />
+              )}
+            </g>
+          );
+        })}
+      </svg>
+      {/* Hover labels as HTML overlays — never SVG text inside the track */}
+      {members.map((e, i) => {
+        if (hovered !== e.id) return null;
+        return (
+          <span
+            key={`t-${e.id}`}
+            className="absolute z-50 pointer-events-none text-[10px] font-medium whitespace-nowrap rounded-md"
+            style={{
+              top: i * rowH + dot / 2,
+              right: "calc(100% + 8px)",
+              transform: "translateY(-50%)",
+              padding: "3px 7px",
+              backgroundColor: "var(--text-primary)",
+              color: "var(--bg-surface)",
+              boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+            }}
+          >
+            {e.title}
+          </span>
+        );
+      })}
+      {entities.length > FAN_CAP && (
+        <span
+          className="absolute text-[9px] tabular-nums text-ink-muted whitespace-nowrap"
+          style={{ top: totalH + 2, right: stem }}
+        >
+          +{entities.length - FAN_CAP}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function PeriodHeader({ bucket, active }: { bucket: TimeBucket; active: boolean }) {
+  return (
+    <div className="sticky top-0 z-10 -mx-0.5 px-0.5 py-1 bg-warm flex items-center gap-2">
+      <span
+        className={`text-xs font-semibold tabular-nums ${active ? "text-ink" : "text-ink-secondary"}`}
+      >
+        {bucket.label}
+      </span>
+      <span className="text-[11px] text-ink-tertiary tabular-nums">
+        {bucket.entities.length.toLocaleString()}
+      </span>
+      <span className="flex-1 h-px" style={{ backgroundColor: "var(--border-soft)" }} />
+      <span className="flex items-center gap-1">
+        {colorSpread(bucket.entities, 5).map((c) => (
+          <span key={c} className="w-1.5 h-1.5 rounded-[2px]" style={{ backgroundColor: c }} />
+        ))}
+      </span>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * 2 — SPINE: a true proportional chronology. Every entity sits at its
+ *     exact date on a continuous vertical axis; collisions push down and
+ *     a leader line points back to the real instant.
+ * ------------------------------------------------------------------ */
+
+const PX_PER_YEAR = 190;
+/** One event = one line. The spine is a chronology, NOT a second results list —
+ *  cards here just recreate the List view with extra whitespace. */
+const EVENT_H = 22;
+/** The axis lives on the right, like the rail and the document's ref minimap.
+ *  This is the gutter kept for its year marks. */
+const AXIS_GUTTER = 58;
+const LEADER_W = 22;
+/** The longest stretch of nothing the axis will draw at true scale before it
+ *  elides — see the break markers. */
+const MAX_GAP = 88;
+
+/** "8 months", "3 years" — the size of an elided silence. */
+function elapsed(ms: number): string {
+  const days = ms / 86_400_000;
+  if (days >= 730) return `${Math.round(days / 365.2425)} years`;
+  if (days >= 55) return `${Math.round(days / 30.44)} months`;
+  return `${Math.max(1, Math.round(days))} days`;
+}
+
+function SpineLayout({ dated, selectedId, onSelect }: LayoutProps) {
+  const plotted = dated.slice(0, SPINE_CAP);
+  const extent = useMemo(() => timeExtent(plotted)!, [plotted]);
+
+  const { rows, height, years, gaps } = useMemo(() => {
+    const yearMs = 365.2425 * 86_400_000;
+    // The scale ADAPTS to the density of what's on screen. A fixed px-per-year
+    // makes a single busy year collide into an undifferentiated list (the exact
+    // thing this layout exists to avoid) and a 40-year sweep into a void. Give
+    // every event roughly its own row's worth of axis, and the proportions read.
+    const spanYears = Math.max((extent.max - extent.min) / yearMs, 1 / 365);
+    const scale = Math.min(
+      Math.max((plotted.length * EVENT_H * 1.35) / spanYears, PX_PER_YEAR),
+      40_000,
+    );
+    const raw = (t: number) => 6 + ((t - extent.min) / yearMs) * scale;
+
+    // A long silence is information, but 700px of white is not. Anything longer
+    // than MAX_GAP collapses to MAX_GAP and gets a labelled break, so the axis
+    // stays proportional WHERE THE EVENTS ARE and elides where they aren't.
+    const cuts: { atRaw: number; cut: number }[] = [];
+    const gaps: { y: number; ms: number }[] = [];
+    let accum = 0;
+    let prevRaw = raw(extent.min);
+    let prevT = extent.min;
+    let cursor = 0;
+    const rows = plotted.map((e) => {
+      const t = entityTime(e)!;
+      const r = raw(t);
+      const delta = r - prevRaw;
+      let broke = 0;
+      if (delta > MAX_GAP) {
+        const cut = delta - MAX_GAP;
+        cuts.push({ atRaw: r, cut });
+        accum += cut;
+        broke = t - prevT;
+      }
+      prevRaw = r;
+      prevT = t;
+      const ideal = r - accum;
+      const y = Math.max(ideal, cursor);
+      // The break marker goes between the LAID-OUT rows, not at the ideal
+      // position — collision-pushed neighbours would sit on top of it.
+      if (broke) gaps.push({ y: (cursor + y) / 2, ms: broke });
+      cursor = y + EVENT_H;
+      return { e, t, y, ideal };
+    });
+    const at = (t: number) => {
+      const r = raw(t);
+      let a = 0;
+      for (const c of cuts) if (c.atRaw <= r) a += c.cut;
+      return r - a;
+    };
+    const height = cursor + 24;
+
+    // Marks: years across a long sweep, months once the range is short enough
+    // that "2009" alone would be the only label on the whole axis.
+    const years: { label: string; y: number }[] = [];
+    const d0 = new Date(extent.min);
+    const d1 = new Date(extent.max);
+    if (spanYears < 2.5) {
+      const step = spanYears < 0.6 ? 1 : 3;
+      for (
+        let m = new Date(Date.UTC(d0.getUTCFullYear(), d0.getUTCMonth(), 1));
+        m.getTime() <= extent.max;
+        m = new Date(Date.UTC(m.getUTCFullYear(), m.getUTCMonth() + step, 1))
+      ) {
+        const pos = at(m.getTime());
+        if (pos >= 0) years.push({ label: bucketOf(m.getTime(), "month").label, y: pos });
+      }
+    } else {
+      const y0 = d0.getUTCFullYear();
+      const y1 = d1.getUTCFullYear();
+      const step = y1 - y0 > 40 ? 5 : y1 - y0 > 12 ? 2 : 1;
+      for (let y = y0; y <= y1; y += step) {
+        const pos = at(Date.UTC(y, 0, 1));
+        if (pos >= 0) years.push({ label: String(y), y: pos });
+      }
+    }
+    // The first mark is often clipped (a range starting 17 Jan has no 1 Jan
+    // tick above it) — anchor the top of the axis explicitly.
+    if (!years.length || years[0].y > 14) {
+      years.unshift({
+        label: bucketOf(extent.min, spanYears < 2.5 ? "month" : "year").label,
+        y: 6,
+      });
+    }
+    return { rows, height, years, gaps };
+  }, [plotted, extent]);
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="relative" style={{ height }}>
+        {/* Axis — right rail */}
+        <div
+          className="absolute top-0 bottom-0"
+          style={{
+            insetInlineEnd: AXIS_GUTTER,
+            width: 1,
+            backgroundColor: "var(--border-primary)",
+          }}
+        />
+        {years.map((y) => (
+          <div
+            key={y.label}
+            className="absolute flex items-center gap-1 -translate-y-1/2"
+            style={{ top: y.y, insetInlineEnd: 0 }}
+          >
+            <span className="w-1.5 h-px" style={{ backgroundColor: "var(--border-primary)" }} />
+            <span className="w-12 text-[9px] tabular-nums text-ink-tertiary whitespace-nowrap">
+              {y.label}
+            </span>
+          </div>
+        ))}
+
+        {/* Elided silences */}
+        {gaps.map((g) => (
+          <div
+            key={`gap-${g.y}`}
+            className="absolute flex items-center gap-2 pointer-events-none -translate-y-1/2"
+            style={{ top: g.y, insetInlineStart: 0, insetInlineEnd: AXIS_GUTTER - 4 }}
+          >
+            <span className="flex-1 h-px" style={{ backgroundColor: "transparent" }} />
+            <span className="text-[10px] italic text-ink-muted">{elapsed(g.ms)} later</span>
+            <span
+              className="w-8 h-px"
+              style={{
+                backgroundImage:
+                  "repeating-linear-gradient(to right, var(--border-primary) 0 3px, transparent 3px 6px)",
+              }}
+            />
+          </div>
+        ))}
+
+        {rows.map(({ e, t, y, ideal }) => {
+          const color = getEntityType(e.typeId)?.color ?? "#6B7280";
+          const drop = Math.max(1, y - ideal);
+          const sel = selectedId === e.id;
+          return (
+            <div key={e.id}>
+              {/* Leader from the true instant on the axis to the pushed row */}
+              <svg
+                className="absolute pointer-events-none"
+                style={{
+                  insetInlineEnd: AXIS_GUTTER - 4,
+                  top: ideal,
+                  width: LEADER_W,
+                  height: drop + 1,
+                  overflow: "visible",
+                }}
+                aria-hidden
+              >
+                <path
+                  d={`M ${LEADER_W - 4} 0 C ${LEADER_W - 13} 0, ${LEADER_W - 9} ${drop}, 0 ${drop}`}
+                  fill="none"
+                  stroke="var(--border-primary)"
+                  strokeWidth={1}
+                />
+                <circle cx={LEADER_W - 4} cy={0} r={2.5} fill={color} opacity={sel ? 1 : 0.7} />
+              </svg>
+
+              <button
+                onClick={() => onSelect(e.id)}
+                aria-pressed={sel}
+                className={`absolute flex items-center gap-2 h-[22px] px-2 rounded-md text-start cursor-pointer
+                  transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-carbon/30 ${
+                    sel ? "bg-parchment" : "hover:bg-parchment"
+                  }`}
+                style={{
+                  top: y - EVENT_H / 2 + 1,
+                  insetInlineStart: 0,
+                  insetInlineEnd: AXIS_GUTTER + LEADER_W,
+                }}
+              >
+                <span
+                  className="shrink-0 w-1.5 h-1.5 rounded-[2px]"
+                  style={{ backgroundColor: color }}
+                />
+                <span className="shrink-0 w-[5.5rem] text-[10px] tabular-nums text-ink-tertiary">
+                  {formatDay(t)}
+                </span>
+                <span
+                  className={`flex-1 min-w-0 truncate text-xs ${sel ? "text-ink font-medium" : "text-ink-secondary"}`}
+                >
+                  {e.title}
+                </span>
+                <span className="shrink-0 text-[10px] text-ink-muted hidden md:block">
+                  {getEntityType(e.typeId)?.name ?? e.typeId}
+                </span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {dated.length > SPINE_CAP && (
+        <div className="py-3 text-center text-[11px] text-ink-muted">
+          Plotting the first {SPINE_CAP} of {dated.length.toLocaleString()} — narrow the range to see
+          the rest.
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * 3 — LANES: a template × period density grid. One lane per template,
+ *     one cell per period; the cell is a dot sized by count. Clicking a
+ *     cell drills in — it sets the template facet AND the date range.
+ * ------------------------------------------------------------------ */
+
+function LanesLayout({ laneChart }: LayoutProps) {
+  const [typeFilters, setTypeFilters] = useAtom(libraryTypeFiltersAtom);
+  const [hover, setHover] = useState<string | null>(null);
+  const range = useRange();
+
+  const dated = useMemo(() => sortByTime(laneChart), [laneChart]);
+  const extent = useMemo(() => timeExtent(dated), [dated]);
+  const unit = useMemo(() => (extent ? pickUnit(extent.max - extent.min) : "year"), [extent]);
+
+  const { cols, lanes, max } = useMemo(() => {
+    const cols = groupByBucket(dated, unit);
+    const byType = new Map<string, Map<string, Entity[]>>();
+    for (const c of cols) {
+      for (const e of c.entities) {
+        const lane = byType.get(e.typeId) ?? new Map<string, Entity[]>();
+        const cell = lane.get(c.key) ?? [];
+        cell.push(e);
+        lane.set(c.key, cell);
+        byType.set(e.typeId, lane);
+      }
+    }
+    let max = 1;
+    for (const lane of byType.values())
+      for (const cell of lane.values()) max = Math.max(max, cell.length);
+    const lanes = [...byType.entries()]
+      .map(([typeId, cells]) => ({
+        typeId,
+        name: getEntityType(typeId)?.name ?? typeId,
+        color: getEntityType(typeId)?.color ?? "#6B7280",
+        cells,
+        total: [...cells.values()].reduce((n, c) => n + c.length, 0),
+      }))
+      .sort((a, b) => b.total - a.total);
+    return { cols, lanes, max };
+  }, [dated, unit]);
+
+  if (!cols.length) return null;
+
+  const anyType = Object.values(typeFilters).some(Boolean);
+  const colW = 26;
+
+  return (
+    <div className="h-full overflow-auto">
+      <div dir="ltr" className="inline-block min-w-full">
+        {/* Column heads */}
+        <div className="flex sticky top-0 z-10 bg-warm pb-1">
+          <div className="shrink-0 w-40" />
+          {cols.map((c, i) => (
+            <div key={c.key} className="shrink-0 text-center" style={{ width: colW }}>
+              {i % Math.ceil(cols.length / 16 || 1) === 0 && (
+                <span className="block text-[9px] tabular-nums text-ink-muted -rotate-45 origin-center whitespace-nowrap">
+                  {c.label}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {lanes.map((lane) => {
+          const laneOn = !anyType || !!typeFilters[lane.typeId];
+          return (
+            <div key={lane.typeId} className="flex items-center h-8">
+              <div className="shrink-0 w-40 pe-2 flex items-center gap-1.5 min-w-0">
+                <span
+                  className="w-2 h-2 rounded-[2px] shrink-0"
+                  style={{ backgroundColor: lane.color, opacity: laneOn ? 1 : 0.35 }}
+                />
+                <span
+                  className={`text-[11px] font-medium truncate ${laneOn ? "text-ink-secondary" : "text-ink-muted"}`}
+                >
+                  {lane.name}
+                </span>
+                <span className="ms-auto text-[10px] tabular-nums text-ink-muted">
+                  {lane.total.toLocaleString()}
+                </span>
+              </div>
+              {cols.map((c) => {
+                const cell = lane.cells.get(c.key);
+                const n = cell?.length ?? 0;
+                const id = `${lane.typeId}:${c.key}`;
+                const r = n ? 5 + Math.sqrt(n / max) * 9 : 0;
+                const inRange = range.overlaps(c);
+                const picked = laneOn && !range.isAll && range.covers(c) && anyType;
+                return (
+                  <div
+                    key={c.key}
+                    className="shrink-0 h-full flex items-center justify-center relative"
+                    style={{ width: colW }}
+                  >
+                    {n > 0 && (
+                      <button
+                        aria-label={`${lane.name} · ${c.label} · ${n} ${n === 1 ? "entity" : "entities"}`}
+                        aria-pressed={picked}
+                        onClick={() => {
+                          setTypeFilters(picked ? {} : { [lane.typeId]: true });
+                          range.toggle(c);
+                        }}
+                        onMouseEnter={() => setHover(id)}
+                        onMouseLeave={() => setHover(null)}
+                        className="rounded-full transition-transform cursor-pointer hover:scale-110
+                          focus:outline-none focus-visible:ring-2 focus-visible:ring-carbon/40"
+                        style={{
+                          width: r * 2,
+                          height: r * 2,
+                          backgroundColor: lane.color,
+                          opacity: laneOn && inRange ? (picked ? 1 : 0.72) : 0.16,
+                          boxShadow: picked ? `0 0 0 2px ${lane.color}55` : "none",
+                        }}
+                      />
+                    )}
+                    {hover === id && (
+                      <span
+                        className="absolute z-50 bottom-full mb-1 pointer-events-none text-[10px] font-medium whitespace-nowrap rounded-md"
+                        style={{
+                          padding: "3px 7px",
+                          backgroundColor: "var(--text-primary)",
+                          color: "var(--bg-surface)",
+                          boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+                        }}
+                      >
+                        {c.label} · {n.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+
+        <p className="pt-3 text-[11px] text-ink-muted">
+          A dot is one period of one template, sized by how many entities landed in it. Click one to
+          filter the Library to that slice; click it again to clear.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export const TIMELINE_LAYOUTS: { id: TimelineLayout; label: string }[] = [
+  { id: "rail", label: "Rail" },
+  { id: "density", label: "Density" },
+  { id: "spine", label: "Spine" },
+  { id: "lanes", label: "Lanes" },
+];

--- a/app/src/components/library/TimeBrush.tsx
+++ b/app/src/components/library/TimeBrush.tsx
@@ -20,6 +20,11 @@ interface DragState {
   grabMs: number;
   from: number;
   to: number;
+  /** Where the pointer went down. A gesture that ends near here is a TAP, not a
+   *  drag — whatever mode it started in. (When the range is full the window
+   *  overlay covers the whole strip, so a plain click arrives as a "pan".) */
+  origin: number;
+  moved: boolean;
 }
 
 /** The Bellingcat-style time strip: a density histogram of the (date-unfiltered)
@@ -116,6 +121,7 @@ export function TimeBrush({ entities }: { entities: Entity[] }) {
     const span = axis.max - axis.min;
     const MIN_WIN = span / 200;
     const at = msAt(ev.clientX);
+    if (Math.abs(at - d.origin) > span / 300) d.moved = true;
     let next: DragState;
     if (d.mode === "start") next = { ...d, from: Math.min(at, d.to - MIN_WIN) };
     else if (d.mode === "end") next = { ...d, to: Math.max(at, d.from + MIN_WIN) };
@@ -137,9 +143,18 @@ export function TimeBrush({ entities }: { entities: Entity[] }) {
     setDrag(null);
     if (!d || !axis) return;
     trackRef.current?.releasePointerCapture?.(ev.pointerId);
-    // A tap (a "new" drag that never moved) shouldn't collapse the window to an
-    // instant — leave the range alone.
-    if (d.mode === "new" && d.to - d.from < (axis.max - axis.min) / 200) return;
+
+    // Tap (no real movement) → select the PERIOD under the pointer, exactly like
+    // clicking a bar on the Density track. Tap the selected period again to clear.
+    if (!d.moved) {
+      const hit = bucketsRef.current.find((b) => d.origin >= b.start && d.origin < b.end);
+      if (!hit) return;
+      const alreadyOn =
+        fromMs !== null && toMs !== null && hit.start >= fromMs && hit.end - 1 <= toMs + 86_399_999;
+      if (alreadyOn) commit(axis.min, axis.max, true);
+      else commit(hit.start, hit.end - 86_400_000, false);
+      return;
+    }
     commit(d.from, d.to, d.from <= axis.min && d.to >= axis.max);
   };
 
@@ -190,8 +205,8 @@ export function TimeBrush({ entities }: { entities: Entity[] }) {
     const at = msAt(ev.clientX);
     const d: DragState =
       mode === "new"
-        ? { mode, grabMs: at, from: at, to: at }
-        : { mode, grabMs: at, from: winFrom, to: winTo };
+        ? { mode, grabMs: at, from: at, to: at, origin: at, moved: false }
+        : { mode, grabMs: at, from: winFrom, to: winTo, origin: at, moved: false };
     dragRef.current = d;
     setDrag(d);
     // Capture on the track, so moves that leave the strip still land here.

--- a/app/src/components/library/TimeBrush.tsx
+++ b/app/src/components/library/TimeBrush.tsx
@@ -1,0 +1,439 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useAtom } from "jotai";
+import { libraryDateFromAtom, libraryDateToAtom } from "../../atoms/library";
+import {
+  bucketSeries,
+  entityTime,
+  formatDay,
+  pickUnit,
+  stackByType,
+  timeExtent,
+  toISODate,
+  typeOrder,
+  type TimeBucket,
+} from "../../utils/timeline";
+import { BucketBreakdown, ChartTip } from "./BucketBreakdown";
+import type { Entity } from "../../data/entities";
+
+interface DragState {
+  mode: "start" | "end" | "pan" | "new";
+  grabMs: number;
+  from: number;
+  to: number;
+}
+
+/** The Bellingcat-style time strip: a density histogram of the (date-unfiltered)
+ *  results with a draggable range window over it. It writes the SAME
+ *  `libraryDateFrom/To` atoms the Filters panel uses, so brushing narrows every
+ *  view — cards, list, map, timeline — and shows up as the usual filter chip.
+ *
+ *  `entities` must be the results filtered by everything EXCEPT the date facet
+ *  (`matchesAll(e, state, "date")`), so the bars keep showing what you'd get
+ *  back by widening the window. */
+export function TimeBrush({ entities }: { entities: Entity[] }) {
+  const [dateFrom, setDateFrom] = useAtom(libraryDateFromAtom);
+  const [dateTo, setDateTo] = useAtom(libraryDateToAtom);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [hovered, setHovered] = useState<TimeBucket | null>(null);
+  // The live window during a drag. Held in a ref as well as state: the ref is
+  // written synchronously in pointerdown, so a fast flick whose pointermove
+  // lands before React has re-rendered still resolves.
+  const dragRef = useRef<DragState | null>(null);
+  const [drag, setDrag] = useState<DragState | null>(null);
+
+  const extent = useMemo(() => timeExtent(entities), [entities]);
+  const unit = useMemo(() => (extent ? pickUnit(extent.max - extent.min) : "year"), [extent]);
+  const buckets = useMemo(
+    () => (extent ? bucketSeries(entities, unit, extent) : []),
+    [entities, unit, extent],
+  );
+  // The shape carries no colour, so the ONLY place a period's composition shows
+  // is the hover tooltip — hence the stable order still matters here.
+  const order = useMemo(() => typeOrder(entities), [entities]);
+  // Read by the pointer-driven hover handler, which is defined before `buckets`.
+  const bucketsRef = useRef<TimeBucket[]>([]);
+  bucketsRef.current = buckets;
+
+  // The strip's own axis spans whole buckets, so the first and last bar aren't
+  // clipped by an extent that lands mid-bucket.
+  const axis = useMemo(() => {
+    if (!buckets.length) return null;
+    return { min: buckets[0].start, max: buckets[buckets.length - 1].end };
+  }, [buckets]);
+
+  const fromMs = dateFrom ? Date.parse(dateFrom) : null;
+  const toMs = dateTo ? Date.parse(dateTo) : null;
+  const winFrom = drag ? drag.from : fromMs ?? axis?.min ?? 0;
+  const winTo = drag ? drag.to : toMs ?? axis?.max ?? 0;
+
+  const inRange = useMemo(
+    () =>
+      entities.filter((e) => {
+        const t = entityTime(e);
+        return t !== null && t >= winFrom && t <= winTo;
+      }).length,
+    [entities, winFrom, winTo],
+  );
+
+  const commit = useCallback(
+    (from: number, to: number, full: boolean) => {
+      if (full) {
+        setDateFrom("");
+        setDateTo("");
+      } else {
+        setDateFrom(toISODate(from));
+        setDateTo(toISODate(to));
+      }
+    },
+    [setDateFrom, setDateTo],
+  );
+
+  const msAt = useCallback(
+    (clientX: number) => {
+      const el = trackRef.current;
+      if (!el || !axis) return 0;
+      const r = el.getBoundingClientRect();
+      const f = Math.min(1, Math.max(0, (clientX - r.left) / r.width));
+      return axis.min + f * (axis.max - axis.min);
+    },
+    [axis],
+  );
+
+  /** Hover is derived from the pointer's x, NOT from per-bucket pointerenter:
+   *  the draggable window overlay covers the track, so it would swallow every
+   *  enter event on the columns beneath it. */
+  const onHover = (ev: React.PointerEvent) => {
+    if (!axis || !bucketsRef.current.length) return;
+    const at = msAt(ev.clientX);
+    const hit = bucketsRef.current.find((b) => at >= b.start && at < b.end) ?? null;
+    setHovered((prev) => (prev?.key === hit?.key ? prev : hit));
+  };
+
+  const onMove = (ev: React.PointerEvent) => {
+    onHover(ev);
+    const d = dragRef.current;
+    if (!d || !axis) return;
+    const span = axis.max - axis.min;
+    const MIN_WIN = span / 200;
+    const at = msAt(ev.clientX);
+    let next: DragState;
+    if (d.mode === "start") next = { ...d, from: Math.min(at, d.to - MIN_WIN) };
+    else if (d.mode === "end") next = { ...d, to: Math.max(at, d.from + MIN_WIN) };
+    else if (d.mode === "new")
+      next = { ...d, from: Math.min(d.grabMs, at), to: Math.max(d.grabMs, at) };
+    else {
+      // pan — keep the window width, clamp to the axis
+      const w = d.to - d.from;
+      const from = Math.max(axis.min, Math.min(d.from + (at - d.grabMs), axis.max - w));
+      next = { ...d, from, to: from + w, grabMs: at };
+    }
+    dragRef.current = next;
+    setDrag(next);
+  };
+
+  const onUp = (ev: React.PointerEvent) => {
+    const d = dragRef.current;
+    dragRef.current = null;
+    setDrag(null);
+    if (!d || !axis) return;
+    trackRef.current?.releasePointerCapture?.(ev.pointerId);
+    // A tap (a "new" drag that never moved) shouldn't collapse the window to an
+    // instant — leave the range alone.
+    if (d.mode === "new" && d.to - d.from < (axis.max - axis.min) / 200) return;
+    commit(d.from, d.to, d.from <= axis.min && d.to >= axis.max);
+  };
+
+  if (!axis || !buckets.length) return null;
+
+  const span = axis.max - axis.min;
+  const pct = (ms: number) => ((ms - axis.min) / span) * 100;
+  const maxCount = Math.max(1, ...buckets.map((b) => b.entities.length));
+  const isFull = !dateFrom && !dateTo;
+
+  // The silhouette, in a 0..100 × 0..100 space (y is inverted: 100 = baseline).
+  const shape = (() => {
+    if (!buckets.length) return "";
+    let d = `M 0 100`;
+    for (const b of buckets) {
+      const n = b.entities.length;
+      const y = 100 - (n ? 8 + Math.sqrt(n / maxCount) * 92 : 0);
+      d += ` L ${pct(b.start)} ${y} L ${pct(b.end)} ${y}`;
+    }
+    d += ` L 100 100 Z`;
+    return d;
+  })();
+
+  // Zoom presets — the last N of the axis, sized to the corpus span.
+  const YEAR = 365.2425 * 86_400_000;
+  const presets: { label: string; ms: number }[] = (
+    span / YEAR > 8
+      ? [
+          { label: "20y", ms: 20 * YEAR },
+          { label: "10y", ms: 10 * YEAR },
+          { label: "5y", ms: 5 * YEAR },
+          { label: "1y", ms: YEAR },
+        ]
+      : [
+          { label: "12m", ms: YEAR },
+          { label: "6m", ms: YEAR / 2 },
+          { label: "3m", ms: YEAR / 4 },
+        ]
+  ).filter((p) => p.ms < span);
+
+  // Axis ticks — every Nth bucket boundary, thinned to fit.
+  const tickEvery = Math.max(1, Math.ceil(buckets.length / 12));
+  const ticks = buckets.filter((_, i) => i % tickEvery === 0);
+
+  const startDrag = (mode: DragState["mode"]) => (ev: React.PointerEvent) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    const at = msAt(ev.clientX);
+    const d: DragState =
+      mode === "new"
+        ? { mode, grabMs: at, from: at, to: at }
+        : { mode, grabMs: at, from: winFrom, to: winTo };
+    dragRef.current = d;
+    setDrag(d);
+    // Capture on the track, so moves that leave the strip still land here.
+    trackRef.current?.setPointerCapture?.(ev.pointerId);
+  };
+
+  const nudge = (which: "start" | "end", dir: 1 | -1) => {
+    const step = buckets[0].end - buckets[0].start;
+    const next =
+      which === "start"
+        ? { from: Math.max(axis.min, Math.min(winFrom + dir * step, winTo - step)), to: winTo }
+        : { from: winFrom, to: Math.min(axis.max, Math.max(winTo + dir * step, winFrom + step)) };
+    commit(next.from, next.to, false);
+  };
+
+  return (
+    <div
+      dir="ltr"
+      className="shrink-0 bg-paper px-3 pt-1.5 pb-2 select-none"
+      style={{ borderTop: "1px solid var(--border-primary)" }}
+    >
+      {/* Caption + presets */}
+      <div className="flex items-center gap-2 h-6">
+        <span className="text-[11px] text-ink-tertiary tabular-nums whitespace-nowrap">
+          <span className="font-semibold text-ink-secondary">{inRange.toLocaleString()}</span>
+          {" dated · "}
+          <span className="text-ink-secondary">{formatDay(winFrom)}</span>
+          {" → "}
+          <span className="text-ink-secondary">{formatDay(winTo)}</span>
+        </span>
+        <div className="flex-1" />
+        {hovered && (
+          <span className="text-[11px] text-ink-tertiary tabular-nums whitespace-nowrap">
+            {hovered.label} · {hovered.entities.length.toLocaleString()}
+          </span>
+        )}
+        {presets.map((p) => (
+          <button
+            key={p.label}
+            onClick={() => commit(axis.max - p.ms, axis.max, false)}
+            className="px-2 h-5 text-[11px] font-medium rounded-md bg-warm text-ink-tertiary hover:bg-parchment hover:text-ink transition-colors cursor-pointer"
+          >
+            {p.label}
+          </button>
+        ))}
+        <button
+          onClick={() => commit(axis.min, axis.max, true)}
+          disabled={isFull}
+          className={`px-2 h-5 text-[11px] font-medium rounded-md transition-colors ${
+            isFull
+              ? "text-ink-muted"
+              : "bg-warm text-ink-tertiary hover:bg-parchment hover:text-ink cursor-pointer"
+          }`}
+        >
+          All
+        </button>
+      </div>
+
+      {/* Track */}
+      <div
+        ref={trackRef}
+        className="relative h-11 cursor-crosshair touch-none"
+        onPointerDown={startDrag("new")}
+        onPointerMove={onMove}
+        onPointerUp={onUp}
+        onPointerCancel={onUp}
+        onPointerLeave={() => setHovered(null)}
+      >
+        {/* The volume SHAPE — one stepped area off the baseline, not N stacked
+            bars. Steps, not a spline: each bucket is a discrete count, and a
+            smooth curve would draw values between periods nobody measured.
+            (An SVG is a replaced element — with only top/bottom set it would
+            take its intrinsic viewBox height and ignore `bottom`. State it.) */}
+        <svg
+          className="absolute inset-0 pointer-events-none"
+          style={{ width: "100%", height: "100%" }}
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          aria-hidden
+        >
+          <defs>
+            <clipPath id="brush-window" clipPathUnits="userSpaceOnUse">
+              <rect
+                x={pct(winFrom)}
+                y={0}
+                width={Math.max(0, pct(winTo) - pct(winFrom))}
+                height={100}
+              />
+            </clipPath>
+          </defs>
+          {/* Whole span, receded — what widening the window would give back */}
+          <path d={shape} fill="var(--accent-blue)" opacity={isFull ? 0.16 : 0.08} />
+          {/* Inside the window, lit */}
+          <g clipPath="url(#brush-window)">
+            <path d={shape} fill="var(--accent-blue)" opacity={0.26} />
+            <path
+              d={shape}
+              fill="none"
+              stroke="var(--accent-blue)"
+              strokeWidth={1}
+              strokeOpacity={0.85}
+              vectorEffect="non-scaling-stroke"
+            />
+          </g>
+        </svg>
+
+        {/* Hover readout — purely visual (the track owns the pointer). */}
+        <div className="absolute inset-0 flex items-end pointer-events-none">
+          {buckets.map((b) => {
+            const n = b.entities.length;
+            const h = n ? 8 + Math.sqrt(n / maxCount) * 92 : 0;
+            const isHov = hovered?.key === b.key;
+            return (
+              <div
+                key={b.key}
+                className="relative flex-1 min-w-0 h-full flex items-end justify-center"
+              >
+                {isHov && (
+                  <>
+                    {/* Marker up to the shape's edge at this period */}
+                    <span
+                      className="absolute bottom-0 left-1/2 -translate-x-1/2 pointer-events-none"
+                      style={{
+                        width: 1,
+                        height: `${h}%`,
+                        backgroundColor: "var(--text-primary)",
+                      }}
+                    />
+                    <span
+                      className="absolute left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full pointer-events-none"
+                      style={{
+                        bottom: `calc(${h}% - 2px)`,
+                        width: 5,
+                        height: 5,
+                        backgroundColor: "var(--text-primary)",
+                      }}
+                    />
+                    <span
+                      className="absolute left-1/2 pointer-events-none"
+                      style={{ bottom: `${h}%` }}
+                    >
+                      <ChartTip anchor="above">
+                        <BucketBreakdown
+                          label={b.label}
+                          total={n}
+                          slices={stackByType(b.entities, order)}
+                        />
+                      </ChartTip>
+                    </span>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Baseline */}
+        <div
+          className="absolute left-0 right-0 bottom-0"
+          style={{ height: 1, backgroundColor: "var(--border-primary)" }}
+        />
+
+        {/* Out-of-range scrims */}
+        {!isFull && (
+          <>
+            <div
+              className="absolute top-0 bottom-0 left-0 pointer-events-none"
+              style={{ width: `${pct(winFrom)}%`, backgroundColor: "var(--bg-warm)", opacity: 0.6 }}
+            />
+            <div
+              className="absolute top-0 bottom-0 pointer-events-none"
+              style={{
+                left: `${pct(winTo)}%`,
+                right: 0,
+                backgroundColor: "var(--bg-warm)",
+                opacity: 0.6,
+              }}
+            />
+          </>
+        )}
+
+        {/* Window */}
+        <div
+          className="absolute top-0 bottom-0 cursor-grab active:cursor-grabbing"
+          style={{
+            left: `${pct(winFrom)}%`,
+            width: `${pct(winTo) - pct(winFrom)}%`,
+            borderInline: "1px solid var(--accent-blue)",
+            backgroundColor: "color-mix(in srgb, var(--accent-blue) 7%, transparent)",
+          }}
+          onPointerDown={startDrag("pan")}
+        />
+
+        {/* Handles */}
+        {(["start", "end"] as const).map((which) => (
+          <div
+            key={which}
+            role="slider"
+            tabIndex={0}
+            aria-label={which === "start" ? "Range start" : "Range end"}
+            aria-valuemin={axis.min}
+            aria-valuemax={axis.max}
+            aria-valuenow={which === "start" ? winFrom : winTo}
+            aria-valuetext={formatDay(which === "start" ? winFrom : winTo)}
+            onPointerDown={startDrag(which)}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowLeft") (e.preventDefault(), nudge(which, -1));
+              if (e.key === "ArrowRight") (e.preventDefault(), nudge(which, 1));
+            }}
+            className="absolute top-0 bottom-0 w-3 -ml-1.5 flex items-center justify-center cursor-ew-resize
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-carbon/40 rounded-sm"
+            style={{ left: `${pct(which === "start" ? winFrom : winTo)}%` }}
+          >
+            <span
+              className="rounded-full"
+              style={{
+                width: 3,
+                height: "72%",
+                backgroundColor: "var(--accent-blue)",
+              }}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Axis */}
+      <div className="relative h-3.5">
+        {ticks.map((b) => {
+          // Clamp the end ticks so they don't hang off the strip.
+          const p = pct(b.start);
+          const shift = p < 4 ? "none" : p > 96 ? "translateX(-100%)" : "translateX(-50%)";
+          return (
+            <span
+              key={b.key}
+              className="absolute top-0 text-[9px] tabular-nums whitespace-nowrap"
+              style={{ left: `${p}%`, transform: shift, color: "var(--text-muted)" }}
+            >
+              {b.label}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/library/TimeBrush.tsx
+++ b/app/src/components/library/TimeBrush.tsx
@@ -297,8 +297,11 @@ export function TimeBrush({ entities }: { entities: Entity[] }) {
               />
             </clipPath>
           </defs>
-          {/* Whole span, receded — what widening the window would give back */}
-          <path d={shape} fill="var(--accent-blue)" opacity={isFull ? 0.16 : 0.08} />
+          {/* Whole span, receded — what widening the window would give back. It
+              has to stay legible: at 0.08 a narrow window made the rest of the
+              corpus vanish, which is the failure this two-layer draw exists to
+              prevent. */}
+          <path d={shape} fill="var(--accent-blue)" opacity={isFull ? 0.18 : 0.14} />
           {/* Inside the window, lit */}
           <g clipPath="url(#brush-window)">
             <path d={shape} fill="var(--accent-blue)" opacity={0.26} />

--- a/app/src/components/relationships/EntityOverlay.tsx
+++ b/app/src/components/relationships/EntityOverlay.tsx
@@ -9,6 +9,7 @@ import { getEntity } from "../../data/entities";
 import { relationshipFieldsByLanguage, type MetadataField } from "../../data/metadata";
 import { getEntityProfile } from "../../data/entityProfiles";
 import { EntityPill } from "../shared/EntityPill";
+import { EntityIdentity } from "../shared/EntityIdentity";
 import { PageTag } from "../shared/PageTag";
 import { FadeTruncate } from "../shared/FadeTruncate";
 import { EditInput } from "../metadata/EditInput";
@@ -172,20 +173,13 @@ export function EntityOverlay() {
           className="flex items-start justify-between px-4 py-3 shrink-0"
           style={{ borderBottom: "1px solid var(--border-primary)" }}
         >
-          {/* Type tag stacked above the title — the tag's dot carries the
-              entity colour, so no separate dot. */}
-          <div className="min-w-0 space-y-1">
-            <div>
-              <EntityPill typeId={entity?.typeId ?? ""} />
-            </div>
-            <div className="text-sm font-semibold text-ink truncate">
-              {entity?.title}
-            </div>
-          </div>
+          {/* Same identity block as the Library drawer — one component, so the
+              two panels can't drift apart. */}
+          <EntityIdentity entity={entity} size="sm" />
           <button
             onClick={() => setEntityId(null)}
             aria-label="Close"
-            className="p-1.5 rounded-md hover:bg-warm text-ink-muted hover:text-ink transition-colors shrink-0"
+            className="-mt-0.5 p-1.5 rounded-md hover:bg-warm text-ink-muted hover:text-ink transition-colors shrink-0"
           >
             <X size={16} />
           </button>

--- a/app/src/components/shared/EntityIdentity.tsx
+++ b/app/src/components/shared/EntityIdentity.tsx
@@ -1,0 +1,71 @@
+import { getEntityType, type Entity } from "../../data/entities";
+
+/** The identity block at the top of an entity panel: type eyebrow → title →
+ *  quiet meta line.
+ *
+ *  It replaced a pill stacked over a small title. The pill was a filled, tinted
+ *  chip and the title was `text-xs` — the same size as the metadata labels
+ *  underneath — so the loudest thing in the header was the *template name*, and
+ *  the entity's name read as its caption. Here the type is an eyebrow (a square
+ *  dot in the true type colour + a small-caps label) and the title is a real
+ *  heading. Same information, correct hierarchy.
+ *
+ *  Shared by the Library drawer preview and the EntityOverlay so the two headers
+ *  can't drift apart. */
+export function EntityIdentity({
+  entity,
+  size = "md",
+}: {
+  entity?: Entity;
+  /** `sm` for the slide-over, `md` for the drawer panel. */
+  size?: "sm" | "md";
+}) {
+  const type = entity ? getEntityType(entity.typeId) : undefined;
+  const color = type?.color ?? "#6B7280";
+  const year = entity?.createdAt ? new Date(entity.createdAt).getUTCFullYear() : null;
+
+  // Country and date are context, not headline — one dimmed line, em-dash free
+  // (a missing value is simply absent rather than a row of placeholders).
+  const meta = [entity?.country, year ? String(year) : null].filter(Boolean) as string[];
+
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-1.5">
+        <span
+          className="w-2 h-2 rounded-[2px] shrink-0"
+          style={{ backgroundColor: color }}
+          aria-hidden
+        />
+        <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-ink-tertiary truncate">
+          {type?.name ?? entity?.typeId ?? "Unknown"}
+        </span>
+      </div>
+
+      <h2
+        title={entity?.title}
+        className={`mt-1 font-semibold text-ink leading-snug line-clamp-2 ${
+          size === "sm" ? "text-[15px]" : "text-[17px]"
+        }`}
+      >
+        {entity?.title ?? "Unknown entity"}
+      </h2>
+
+      {meta.length > 0 && (
+        <p className="mt-1 text-[11px] text-ink-tertiary truncate">
+          {meta.map((m, i) => (
+            <span key={m}>
+              {i > 0 && <span className="text-ink-muted px-1">·</span>}
+              {m}
+            </span>
+          ))}
+          {entity && entity.published === false && (
+            <>
+              <span className="text-ink-muted px-1">·</span>
+              <span className="text-ink-muted">Restricted</span>
+            </>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/shared/EntityIdentity.tsx
+++ b/app/src/components/shared/EntityIdentity.tsx
@@ -1,7 +1,6 @@
 import { getEntityType, type Entity } from "../../data/entities";
 
-/** The identity block at the top of an entity panel: type eyebrow → title →
- *  quiet meta line.
+/** The identity block at the top of an entity panel: type eyebrow → title.
  *
  *  It replaced a pill stacked over a small title. The pill was a filled, tinted
  *  chip and the title was `text-xs` — the same size as the metadata labels
@@ -9,6 +8,10 @@ import { getEntityType, type Entity } from "../../data/entities";
  *  the entity's name read as its caption. Here the type is an eyebrow (a square
  *  dot in the true type colour + a small-caps label) and the title is a real
  *  heading. Same information, correct hierarchy.
+ *
+ *  Two lines, not three: a country/date meta line under the title just repeated
+ *  what the Metadata tab says two rows further down, and cost the header a third
+ *  of its height to do it.
  *
  *  Shared by the Library drawer preview and the EntityOverlay so the two headers
  *  can't drift apart. */
@@ -22,11 +25,6 @@ export function EntityIdentity({
 }) {
   const type = entity ? getEntityType(entity.typeId) : undefined;
   const color = type?.color ?? "#6B7280";
-  const year = entity?.createdAt ? new Date(entity.createdAt).getUTCFullYear() : null;
-
-  // Country and date are context, not headline — one dimmed line, em-dash free
-  // (a missing value is simply absent rather than a row of placeholders).
-  const meta = [entity?.country, year ? String(year) : null].filter(Boolean) as string[];
 
   return (
     <div className="min-w-0 flex-1">
@@ -49,23 +47,6 @@ export function EntityIdentity({
       >
         {entity?.title ?? "Unknown entity"}
       </h2>
-
-      {meta.length > 0 && (
-        <p className="mt-1 text-[11px] text-ink-tertiary truncate">
-          {meta.map((m, i) => (
-            <span key={m}>
-              {i > 0 && <span className="text-ink-muted px-1">·</span>}
-              {m}
-            </span>
-          ))}
-          {entity && entity.published === false && (
-            <>
-              <span className="text-ink-muted px-1">·</span>
-              <span className="text-ink-muted">Restricted</span>
-            </>
-          )}
-        </p>
-      )}
     </div>
   );
 }

--- a/app/src/components/shared/EntityIdentity.tsx
+++ b/app/src/components/shared/EntityIdentity.tsx
@@ -44,7 +44,7 @@ export function EntityIdentity({
       <h2
         title={entity?.title}
         className={`mt-1 font-semibold text-ink leading-snug line-clamp-2 ${
-          size === "sm" ? "text-[15px]" : "text-[17px]"
+          size === "sm" ? "text-[13px]" : "text-[15px]"
         }`}
       >
         {entity?.title ?? "Unknown entity"}

--- a/app/src/data/cejil/adapt.ts
+++ b/app/src/data/cejil/adapt.ts
@@ -5,7 +5,7 @@ import type { CejilEntity } from "./types";
 import type { LatLng } from "../geo";
 import { cejilTemplates } from "./templates";
 import { cejilDocBearingIds } from "./profile";
-import { cejilCorpus, cejilLoaded } from "./load";
+import { cejilCorpus, cejilLoaded, cejilRelsByEntity } from "./load";
 
 /** template _id → ordered [{name,label,type}] for resolving display fields. */
 const propsByTemplate = new Map(
@@ -108,11 +108,45 @@ function inheritedOf(e: CejilEntity): Record<string, string[]> | undefined {
   return Object.keys(out).length ? out : undefined;
 }
 
+const DATE_KEYS = ["fecha", "presentaci_n_ante_la_corteidh", "denuncia_ante_la_cidh"];
+
 /** A representative unix-seconds date from the metadata, → ISO, for sort-by-date. */
-function createdOf(e: CejilEntity): string | undefined {
-  for (const key of ["fecha", "presentaci_n_ante_la_corteidh", "denuncia_ante_la_cidh"]) {
+function ownDate(e: CejilEntity): string | undefined {
+  for (const key of DATE_KEYS) {
     const v = e.metadata?.[key]?.[0]?.value;
     if (typeof v === "number" && v > 0) return new Date(v * 1000).toISOString();
+  }
+  return undefined;
+}
+
+/** The entity's date. A GEOLOCATED entity with no date of its own inherits its
+ *  Causa's.
+ *
+ *  Every one of the 373 geolocated entities is undated — a "Geolocalización de
+ *  los hechos del caso" carries coordinates and a país, nothing else. So any date
+ *  filter emptied the map completely: narrow the timeline and every pin vanished,
+ *  because the only entities that CAN be pinned were the only ones with no date.
+ *
+ *  They are connected to their Causa (336 of 343), and the Causa is dated. "The
+ *  geolocation of the events of case X" is dated by case X, so the date comes
+ *  down that relationship and map + timeline finally compose.
+ *
+ *  Deliberately NARROW: only geolocated entities, only from a Causa. Letting any
+ *  undated entity borrow a date from any connected one would invent dates for
+ *  the ~1,100 others — a Persona would silently acquire whichever document
+ *  happened to be first in its relationship list. */
+function createdOf(
+  e: CejilEntity,
+  geo: LatLng | undefined,
+  causaDateBySid: Map<string, string>,
+): string | undefined {
+  const own = ownDate(e);
+  if (own) return own;
+  if (!geo) return undefined;
+  for (const r of cejilRelsByEntity().get(e.sharedId) ?? []) {
+    const other = r.from === e.sharedId ? r.to : r.from;
+    const d = causaDateBySid.get(other);
+    if (d) return d;
   }
   return undefined;
 }
@@ -125,10 +159,20 @@ export function cejilLibraryEntities(): Entity[] {
   if (!cejilLoaded()) return [];
   if (_libraryEntities) return _libraryEntities;
   const docBearing = cejilDocBearingIds();
-  _libraryEntities = cejilCorpus()!
-    .entities.filter((e) => e.language === "es")
+  const es = cejilCorpus()!.entities.filter((e) => e.language === "es");
+
+  // Pass 1: the CAUSA dates, so pass 2 can pull one down a geolocation's edge.
+  const causaDateBySid = new Map<string, string>();
+  for (const e of es) {
+    if (e.templateName !== "Causa") continue;
+    const d = ownDate(e);
+    if (d) causaDateBySid.set(e.sharedId, d);
+  }
+
+  _libraryEntities = es
     .map((e) => {
       const country = countryOf(e);
+      const geo = geoOf(e);
       return {
         id: e.sharedId,
         title: e.title.trim(),
@@ -136,8 +180,8 @@ export function cejilLibraryEntities(): Entity[] {
         published: e.published,
         preview: docBearing.has(e.sharedId) ? ("document" as const) : undefined,
         country,
-        geo: geoOf(e),
-        createdAt: createdOf(e),
+        geo,
+        createdAt: createdOf(e, geo, causaDateBySid),
         fields: fieldsOf(e),
         descriptors: (e.metadata?.descriptores || [])
           .map((v) => (typeof v.label === "string" ? v.label : ""))

--- a/app/src/data/cejil/adapt.ts
+++ b/app/src/data/cejil/adapt.ts
@@ -2,34 +2,10 @@
 // Library. Imported only by the library-data atom (pulls the full entity list).
 import type { Entity } from "../entities";
 import type { CejilEntity } from "./types";
-import { countryCoords } from "../geo";
+import type { LatLng } from "../geo";
 import { cejilTemplates } from "./templates";
 import { cejilDocBearingIds } from "./profile";
 import { cejilCorpus, cejilLoaded } from "./load";
-
-// Approximate centroids for the CEJIL countries (Spanish names), since the mock
-// countryCoords only covers the sample seed. Lets the Library map plot real cases.
-const CEJIL_COORDS: Record<string, { lat: number; lng: number }> = {
-  Bolivia: { lat: -16.3, lng: -63.6 },
-  Brasil: { lat: -10.3, lng: -53.2 },
-  Chile: { lat: -35.7, lng: -71.5 },
-  Colombia: { lat: 4.6, lng: -74.1 },
-  "Costa Rica": { lat: 9.7, lng: -83.8 },
-  "El Salvador": { lat: 13.8, lng: -88.9 },
-  Guatemala: { lat: 15.8, lng: -90.2 },
-  Honduras: { lat: 15.2, lng: -86.2 },
-  México: { lat: 23.6, lng: -102.5 },
-  Nicaragua: { lat: 12.9, lng: -85.2 },
-  Panamá: { lat: 8.5, lng: -80.8 },
-  Paraguay: { lat: -23.4, lng: -58.4 },
-  Perú: { lat: -9.2, lng: -75.0 },
-  "República Dominicana": { lat: 18.7, lng: -70.2 },
-  Surinam: { lat: 4.0, lng: -56.0 },
-  "Trinidad y Tobago": { lat: 10.7, lng: -61.2 },
-  Venezuela: { lat: 6.4, lng: -66.6 },
-  Argentina: { lat: -38.4, lng: -63.6 },
-  Ecuador: { lat: -1.8, lng: -78.2 },
-};
 
 /** template _id → ordered [{name,label,type}] for resolving display fields. */
 const propsByTemplate = new Map(
@@ -81,6 +57,28 @@ function countryOf(e: CejilEntity): string | undefined {
   if (e.templateName === "País") return e.title;
   const pais = e.metadata?.pa_s?.[0];
   return pais && typeof pais.label === "string" ? pais.label : undefined;
+}
+
+/** The entity's REAL geolocation property, if it has one.
+ *
+ *  CEJIL carries genuine coordinates on two keys: `ubicaci_n_geogr_fica_geolocation`
+ *  (the 343 "Geolocalización de los hechos del caso" entities — where the events
+ *  of a case actually happened) and `localizaci_n_geolocation` (the País entities'
+ *  own centroids). 373 entities in all.
+ *
+ *  The map used to plot `country ? COORDS[country] : undefined` — every entity
+ *  that merely NAMED a country got pinned to a hardcoded centroid, so thousands
+ *  of judgments, resolutions and votes appeared as "locations". That is a
+ *  country facet drawn on a map, not a geolocation. If an entity has no
+ *  geolocation property, it has no place on the map. */
+function geoOf(e: CejilEntity): LatLng | undefined {
+  for (const key of ["ubicaci_n_geogr_fica_geolocation", "localizaci_n_geolocation"]) {
+    const v = e.metadata?.[key]?.[0]?.value as { lat?: number; lon?: number } | undefined;
+    if (v && typeof v.lat === "number" && typeof v.lon === "number") {
+      return { lat: v.lat, lng: v.lon };
+    }
+  }
+  return undefined;
 }
 
 /** CEJIL inherited-property facets: each maps a relationship/select metadata key
@@ -138,7 +136,7 @@ export function cejilLibraryEntities(): Entity[] {
         published: e.published,
         preview: docBearing.has(e.sharedId) ? ("document" as const) : undefined,
         country,
-        geo: country ? CEJIL_COORDS[country] ?? countryCoords[country] : undefined,
+        geo: geoOf(e),
         createdAt: createdOf(e),
         fields: fieldsOf(e),
         descriptors: (e.metadata?.descriptores || [])

--- a/app/src/utils/timeline.ts
+++ b/app/src/utils/timeline.ts
@@ -1,0 +1,190 @@
+import { getEntityType, type Entity } from "../data/entities";
+
+/** Time bucketing for the Library timeline surfaces (the brush strip and the
+ *  timeline view bodies). One scale, shared — so the histogram, the vertical
+ *  rail and the spine can never disagree about where a year sits. */
+
+export type TimeUnit = "decade" | "year" | "quarter" | "month";
+
+export interface TimeBucket {
+  key: string;
+  label: string;
+  /** Inclusive start / exclusive end, in ms. */
+  start: number;
+  end: number;
+  entities: Entity[];
+}
+
+export interface Extent {
+  min: number;
+  max: number;
+}
+
+const YEAR_MS = 365.2425 * 86_400_000;
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/** The entity's representative date (Sample: seeded `createdAt`; CEJIL: `Fecha`
+ *  and friends, mapped to `createdAt` by the adapter). null = undated. */
+export function entityTime(e: Entity): number | null {
+  if (!e.createdAt) return null;
+  const t = Date.parse(e.createdAt);
+  return Number.isNaN(t) ? null : t;
+}
+
+export function timeExtent(entities: Entity[]): Extent | null {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const e of entities) {
+    const t = entityTime(e);
+    if (t === null) continue;
+    if (t < min) min = t;
+    if (t > max) max = t;
+  }
+  return min === Infinity ? null : { min, max };
+}
+
+/** Bucket granularity that keeps the histogram legible at any span — a 60-year
+ *  corpus (CEJIL) reads in years, an 18-month one (Sample) in months. */
+export function pickUnit(spanMs: number): TimeUnit {
+  const years = spanMs / YEAR_MS;
+  if (years > 8) return "year";
+  if (years > 2.5) return "quarter";
+  return "month";
+}
+
+/** The bucket a timestamp falls in, for a unit. */
+export function bucketOf(t: number, unit: TimeUnit): Omit<TimeBucket, "entities"> {
+  const d = new Date(t);
+  const y = d.getUTCFullYear();
+  const m = d.getUTCMonth();
+  switch (unit) {
+    case "decade": {
+      const dy = Math.floor(y / 10) * 10;
+      return { key: `${dy}s`, label: `${dy}s`, start: Date.UTC(dy, 0, 1), end: Date.UTC(dy + 10, 0, 1) };
+    }
+    case "year":
+      return { key: `${y}`, label: `${y}`, start: Date.UTC(y, 0, 1), end: Date.UTC(y + 1, 0, 1) };
+    case "quarter": {
+      const q = Math.floor(m / 3) * 3;
+      return {
+        key: `${y}-Q${q / 3 + 1}`,
+        label: `Q${q / 3 + 1} ${y}`,
+        start: Date.UTC(y, q, 1),
+        end: Date.UTC(y, q + 3, 1),
+      };
+    }
+    default:
+      return {
+        key: `${y}-${m + 1}`,
+        label: `${MONTHS[m]} ${y}`,
+        start: Date.UTC(y, m, 1),
+        end: Date.UTC(y, m + 1, 1),
+      };
+  }
+}
+
+/** Contiguous buckets across the extent — INCLUDING empty ones, so a quiet
+ *  decade reads as a gap rather than being silently closed up. */
+export function bucketSeries(entities: Entity[], unit: TimeUnit, extent: Extent): TimeBucket[] {
+  const series: TimeBucket[] = [];
+  const byKey = new Map<string, TimeBucket>();
+  let cursor = bucketOf(extent.min, unit).start;
+  // Guard: a pathological extent can't spin more than a few thousand buckets.
+  for (let i = 0; cursor <= extent.max && i < 5000; i++) {
+    const b = { ...bucketOf(cursor, unit), entities: [] as Entity[] };
+    series.push(b);
+    byKey.set(b.key, b);
+    cursor = b.end;
+  }
+  for (const e of entities) {
+    const t = entityTime(e);
+    if (t === null) continue;
+    byKey.get(bucketOf(t, unit).key)?.entities.push(e);
+  }
+  return series;
+}
+
+/** Non-empty buckets only, chronological — the grouping used by the list bodies. */
+export function groupByBucket(entities: Entity[], unit: TimeUnit): TimeBucket[] {
+  const byKey = new Map<string, TimeBucket>();
+  for (const e of entities) {
+    const t = entityTime(e);
+    if (t === null) continue;
+    const b = bucketOf(t, unit);
+    const hit = byKey.get(b.key) ?? { ...b, entities: [] };
+    hit.entities.push(e);
+    byKey.set(b.key, hit);
+  }
+  return [...byKey.values()]
+    .map((b) => ({
+      ...b,
+      entities: [...b.entities].sort((a, z) => (entityTime(a) ?? 0) - (entityTime(z) ?? 0)),
+    }))
+    .sort((a, b) => a.start - b.start);
+}
+
+export interface TypeSlice {
+  typeId: string;
+  name: string;
+  color: string;
+  n: number;
+  /** Share of the set, 0–1. */
+  frac: number;
+}
+
+/** Template ids ordered by how many entities each holds, across the whole set.
+ *  ONE order for every bar in a chart — a stack whose segment order shuffled
+ *  per-bucket would be unreadable. */
+export function typeOrder(entities: Entity[]): string[] {
+  const tally = new Map<string, number>();
+  for (const e of entities) tally.set(e.typeId, (tally.get(e.typeId) ?? 0) + 1);
+  return [...tally.entries()].sort((a, b) => b[1] - a[1]).map(([id]) => id);
+}
+
+/** Split a bucket into its template segments, in the chart's global order.
+ *  This is what a stacked bar draws — composition AND volume, no plurality lie. */
+export function stackByType(entities: Entity[], order: string[]): TypeSlice[] {
+  const tally = new Map<string, number>();
+  for (const e of entities) tally.set(e.typeId, (tally.get(e.typeId) ?? 0) + 1);
+  const total = entities.length || 1;
+  return order
+    .filter((id) => tally.has(id))
+    .map((id) => {
+      const n = tally.get(id)!;
+      const t = getEntityType(id);
+      return {
+        typeId: id,
+        name: t?.name ?? id,
+        color: t?.color ?? "#6B7280",
+        n,
+        frac: n / total,
+      };
+    });
+}
+
+/** The type colour that dominates a set — the bucket's dot colour. */
+export function dominantColor(entities: Entity[]): string {
+  const tally = new Map<string, number>();
+  for (const e of entities) tally.set(e.typeId, (tally.get(e.typeId) ?? 0) + 1);
+  let best = "";
+  let n = 0;
+  for (const [id, c] of tally) if (c > n) ((best = id), (n = c));
+  return getEntityType(best)?.color ?? "#6B7280";
+}
+
+/** Distinct type colours in a set, most-common first (capped) — for stacked dots. */
+export function colorSpread(entities: Entity[], cap = 4): string[] {
+  const tally = new Map<string, number>();
+  for (const e of entities) tally.set(e.typeId, (tally.get(e.typeId) ?? 0) + 1);
+  return [...tally.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, cap)
+    .map(([id]) => getEntityType(id)?.color ?? "#6B7280");
+}
+
+export const toISODate = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+
+export function formatDay(ms: number): string {
+  const d = new Date(ms);
+  return `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+}

--- a/app/src/views/LibraryView.tsx
+++ b/app/src/views/LibraryView.tsx
@@ -59,7 +59,6 @@ import { LibraryFilters } from "../components/library/LibraryFilters";
 import { LibraryClusterDrawer } from "../components/library/LibraryClusterDrawer";
 import { EntityDrawerPreview } from "../components/library/EntityDrawerPreview";
 import { DisplayMenu } from "../components/library/DisplayMenu";
-import { ActiveFilterChip } from "../components/shared/ActiveFilterChip";
 import { DataTable, type Column } from "../components/shared/DataTable";
 import { EntityTypeChip } from "../components/shared/EntityTypeChip";
 import { Select } from "../components/shared/Select";
@@ -278,10 +277,6 @@ export function LibraryView() {
   useEffect(() => setVisibleCount(DISPLAY_STEP), [filtered]);
   const shown = useMemo(() => filtered.slice(0, visibleCount), [filtered, visibleCount]);
 
-  const toggleType = (id: string) => setTypeFilters((prev) => ({ ...prev, [id]: !prev[id] }));
-  const toggleStatus = (id: string) => setStatusFilters((prev) => ({ ...prev, [id]: !prev[id] }));
-  const toggleCountry = (c: string) => setCountryFilters((prev) => ({ ...prev, [c]: !prev[c] }));
-  const toggleDescriptor = (d: string) => setDescriptorFilters((prev) => ({ ...prev, [d]: !prev[d] }));
   const clearAllFilters = () => {
     setTypeFilters({});
     setHasDocOnly(false);
@@ -439,76 +434,6 @@ export function LibraryView() {
         {menuTrigger}
       </div>
 
-      {/* Active filters — a PERSISTENT bar in the chrome, not a block inside the
-          scrolling results.
-          · Always mounted at a fixed height, so applying or clearing the last
-            filter no longer shoves the whole result set up and down.
-          · One line that scrolls sideways instead of wrapping: a wrapping row
-            changes height as chips come and go, which moved the row under the
-            cursor mid-click and removed the wrong filter.
-          · "Clear all" is pinned to the end, so it never moves either. */}
-      <div
-        className="shrink-0 flex items-center gap-2 h-9 px-3 bg-warm"
-        style={{ borderBottom: "1px solid var(--border-primary)" }}
-      >
-        {activeFilterCount === 0 ? (
-          <span className="text-[11px] text-ink-muted">No filters</span>
-        ) : (
-          <>
-            <div className="flex-1 min-w-0 flex items-center gap-2 overflow-x-auto no-scrollbar">
-              {activeTypeIds.map((id) => (
-              <ActiveFilterChip
-                key={id}
-                label={getEntityType(id)?.name ?? id}
-                color={getEntityType(id)?.color}
-                onRemove={() => toggleType(id)}
-              />
-            ))}
-            {hasDocOnly && <ActiveFilterChip label="Has a document" onRemove={() => setHasDocOnly(false)} />}
-            {wantRestricted && <ActiveFilterChip label="Restricted" onRemove={() => toggleStatus("restricted")} />}
-            {wantPublished && <ActiveFilterChip label="Published" onRemove={() => toggleStatus("published")} />}
-            {activeCountries.map((c) => (
-              <ActiveFilterChip key={`country-${c}`} label={c} onRemove={() => toggleCountry(c)} />
-            ))}
-            {activeDescriptors.map((d) => (
-              <ActiveFilterChip key={`desc-${d}`} label={d} onRemove={() => toggleDescriptor(d)} />
-            ))}
-            {(dateFrom || dateTo) && (
-              <ActiveFilterChip
-                label={`${dateFrom || "…"} → ${dateTo || "…"}`}
-                onRemove={() => {
-                  setDateFrom("");
-                  setDateTo("");
-                }}
-              />
-            )}
-            {activeInherited.flatMap((f) =>
-              [...f.values].map((v) => (
-                <ActiveFilterChip
-                  key={`inh-${f.def.propId}-${v}`}
-                  label={v}
-                  onRemove={() =>
-                    setInheritedFilters((s) => {
-                      const next = { ...(s[f.def.propId] ?? {}) };
-                      delete next[v];
-                      return { ...s, [f.def.propId]: next };
-                    })
-                  }
-                />
-              )),
-            )}
-              {q && <ActiveFilterChip label={`“${query.trim()}”`} onRemove={() => setQuery("")} />}
-            </div>
-            <button
-              onClick={clearAllFilters}
-              className="shrink-0 px-2 h-6 text-[11px] font-medium text-ink-tertiary hover:text-ink hover:bg-parchment rounded-md transition-colors cursor-pointer"
-            >
-              Clear all
-            </button>
-          </>
-        )}
-      </div>
-
       {/* Results */}
       <div
         className={`flex-1 min-h-0 px-3 py-3 bg-warm ${
@@ -625,9 +550,29 @@ export function LibraryView() {
           label="Import / Export CSV"
           onClick={() => setAppView("import-csv")}
         />
+        {/* Result status. Nothing is mounted or unmounted here — only the text
+            changes — so the results above it never move. This is also the only
+            place the active-filter count survives while the drawer is showing an
+            entity instead of the Filters panel; clicking it puts the panel back. */}
         <span className="ms-2 text-[11px] text-ink-tertiary">
-          Showing <span className="font-semibold text-ink-secondary">{shown.length.toLocaleString()}</span> of {filtered.length.toLocaleString()}
+          Showing{" "}
+          <span className="font-semibold text-ink-secondary">{shown.length.toLocaleString()}</span> of{" "}
+          {filtered.length.toLocaleString()}
         </span>
+        {activeFilterCount > 0 && (
+          <button
+            onClick={() => setSelectedId(null)}
+            title="Show the Filters panel"
+            className="inline-flex items-center gap-1 px-1.5 h-5 text-[11px] font-medium rounded-md
+              text-ink-secondary hover:bg-warm hover:text-ink transition-colors cursor-pointer"
+          >
+            <span
+              className="w-1.5 h-1.5 rounded-full"
+              style={{ backgroundColor: "var(--accent-blue)" }}
+            />
+            {activeFilterCount} {activeFilterCount === 1 ? "filter" : "filters"}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/app/src/views/LibraryView.tsx
+++ b/app/src/views/LibraryView.tsx
@@ -439,17 +439,24 @@ export function LibraryView() {
         {menuTrigger}
       </div>
 
-      {/* Results */}
+      {/* Active filters — a PERSISTENT bar in the chrome, not a block inside the
+          scrolling results.
+          · Always mounted at a fixed height, so applying or clearing the last
+            filter no longer shoves the whole result set up and down.
+          · One line that scrolls sideways instead of wrapping: a wrapping row
+            changes height as chips come and go, which moved the row under the
+            cursor mid-click and removed the wrong filter.
+          · "Clear all" is pinned to the end, so it never moves either. */}
       <div
-        className={`flex-1 min-h-0 px-3 py-3 bg-warm ${
-          viewMode === "map" || viewMode === "timeline"
-            ? "flex flex-col overflow-hidden"
-            : "overflow-auto"
-        }`}
+        className="shrink-0 flex items-center gap-2 h-9 px-3 bg-warm"
+        style={{ borderBottom: "1px solid var(--border-primary)" }}
       >
-        {activeFilterCount > 0 && (
-          <div className="flex items-center gap-2 flex-wrap pb-3">
-            {activeTypeIds.map((id) => (
+        {activeFilterCount === 0 ? (
+          <span className="text-[11px] text-ink-muted">No filters</span>
+        ) : (
+          <>
+            <div className="flex-1 min-w-0 flex items-center gap-2 overflow-x-auto no-scrollbar">
+              {activeTypeIds.map((id) => (
               <ActiveFilterChip
                 key={id}
                 label={getEntityType(id)?.name ?? id}
@@ -490,18 +497,26 @@ export function LibraryView() {
                 />
               )),
             )}
-            {q && <ActiveFilterChip label={`“${query.trim()}”`} onRemove={() => setQuery("")} />}
-            {activeFilterCount > 1 && (
-              <button
-                onClick={clearAllFilters}
-                className="text-[11px] font-medium text-ink-tertiary hover:text-ink transition-colors cursor-pointer ms-0.5"
-              >
-                Clear all
-              </button>
-            )}
-          </div>
+              {q && <ActiveFilterChip label={`“${query.trim()}”`} onRemove={() => setQuery("")} />}
+            </div>
+            <button
+              onClick={clearAllFilters}
+              className="shrink-0 px-2 h-6 text-[11px] font-medium text-ink-tertiary hover:text-ink hover:bg-parchment rounded-md transition-colors cursor-pointer"
+            >
+              Clear all
+            </button>
+          </>
         )}
+      </div>
 
+      {/* Results */}
+      <div
+        className={`flex-1 min-h-0 px-3 py-3 bg-warm ${
+          viewMode === "map" || viewMode === "timeline"
+            ? "flex flex-col overflow-hidden"
+            : "overflow-auto"
+        }`}
+      >
         {cejilLoading ? (
           cejilError ? (
             <div className="flex flex-col items-center justify-center h-40 gap-3 text-sm text-ink-muted">

--- a/app/src/views/LibraryView.tsx
+++ b/app/src/views/LibraryView.tsx
@@ -59,6 +59,7 @@ import { LibraryFilters } from "../components/library/LibraryFilters";
 import { LibraryClusterDrawer } from "../components/library/LibraryClusterDrawer";
 import { EntityDrawerPreview } from "../components/library/EntityDrawerPreview";
 import { DisplayMenu } from "../components/library/DisplayMenu";
+import { ActiveFiltersButton } from "../components/library/ActiveFiltersButton";
 import { DataTable, type Column } from "../components/shared/DataTable";
 import { EntityTypeChip } from "../components/shared/EntityTypeChip";
 import { Select } from "../components/shared/Select";
@@ -277,18 +278,6 @@ export function LibraryView() {
   useEffect(() => setVisibleCount(DISPLAY_STEP), [filtered]);
   const shown = useMemo(() => filtered.slice(0, visibleCount), [filtered, visibleCount]);
 
-  const clearAllFilters = () => {
-    setTypeFilters({});
-    setHasDocOnly(false);
-    setStatusFilters({});
-    setCountryFilters({});
-    setDescriptorFilters({});
-    setDateFrom("");
-    setDateTo("");
-    setInheritedFilters({});
-    setChainFilters({});
-    setQuery("");
-  };
 
   // Tap-to-preview on desktop/tablet; tap-to-open on mobile (no side drawer).
   // Previewing focuses the entity so the drawer's tabbed bodies (Relationships /
@@ -559,20 +548,7 @@ export function LibraryView() {
           <span className="font-semibold text-ink-secondary">{shown.length.toLocaleString()}</span> of{" "}
           {filtered.length.toLocaleString()}
         </span>
-        {activeFilterCount > 0 && (
-          <button
-            onClick={() => setSelectedId(null)}
-            title="Show the Filters panel"
-            className="inline-flex items-center gap-1 px-1.5 h-5 text-[11px] font-medium rounded-md
-              text-ink-secondary hover:bg-warm hover:text-ink transition-colors cursor-pointer"
-          >
-            <span
-              className="w-1.5 h-1.5 rounded-full"
-              style={{ backgroundColor: "var(--accent-blue)" }}
-            />
-            {activeFilterCount} {activeFilterCount === 1 ? "filter" : "filters"}
-          </button>
-        )}
+        <ActiveFiltersButton />
       </div>
     </div>
   );

--- a/app/src/views/LibraryView.tsx
+++ b/app/src/views/LibraryView.tsx
@@ -1,6 +1,16 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { Search, X, LayoutGrid, List, Map as MapIcon, Plus, Upload, FileSpreadsheet } from "lucide-react";
+import {
+  Search,
+  X,
+  LayoutGrid,
+  List,
+  Map as MapIcon,
+  CalendarRange,
+  Plus,
+  Upload,
+  FileSpreadsheet,
+} from "lucide-react";
 import { dataSourceAtom, libraryEntitiesAtom, cejilReadyAtom } from "../atoms/dataSource";
 import { loadCejilData, cejilRelsByEntity } from "../data/cejil/load";
 import { referencesAtom } from "../atoms/references";
@@ -43,6 +53,8 @@ import { EntityCard } from "../components/library/EntityCard";
 const LibraryMapView = lazy(() =>
   import("../components/library/LibraryMapView").then((m) => ({ default: m.LibraryMapView })),
 );
+import { LibraryTimelineView } from "../components/library/LibraryTimelineView";
+import { TimeBrush } from "../components/library/TimeBrush";
 import { LibraryFilters } from "../components/library/LibraryFilters";
 import { LibraryClusterDrawer } from "../components/library/LibraryClusterDrawer";
 import { EntityDrawerPreview } from "../components/library/EntityDrawerPreview";
@@ -60,7 +72,7 @@ const DISPLAY_STEP = 120;
 
 export function LibraryView() {
   const entities = useAtomValue(libraryEntitiesAtom);
-  const [dataSource, setDataSource] = useAtom(dataSourceAtom);
+  const dataSource = useAtomValue(dataSourceAtom);
   const [cejilReady, setCejilReady] = useAtom(cejilReadyAtom);
   // Fetch the full CEJIL corpus on demand the first time the source is selected.
   // `cejilRetry` bumps to re-run the effect after a failed load (the loader
@@ -239,6 +251,27 @@ export function LibraryView() {
     return [...list].sort(cmp);
   }, [entities, dataSource, activeTypeIds.join(","), hasDocOnly, wantPublished, wantRestricted, statusActive, activeCountries.join(","), countryMode, activeDescriptors.join(","), descriptorMode, fromMs, toMs, inheritedKey, chainKey, activeChains, language, q, sort, sortDir, countByEntity, searchIndex]);
 
+  // The time brush rides under the two spatial/temporal views — map + timeline —
+  // the Bellingcat pairing: a canvas above, the range you're looking at below.
+  const showBrush = (viewMode === "map" || viewMode === "timeline") && !cejilLoading;
+
+  // The brush's histogram is the results with EVERY facet applied except the
+  // date one — so the bars keep showing what widening the window would give back
+  // (dimmed outside the range), instead of collapsing to the current selection.
+  const timeChart = useMemo(
+    () => (showBrush ? entities.filter((e) => matchesAll(e, filterState, "date")) : []),
+    [entities, dataSource, activeTypeIds.join(","), hasDocOnly, wantPublished, wantRestricted, statusActive, activeCountries.join(","), countryMode, activeDescriptors.join(","), descriptorMode, inheritedKey, chainKey, activeChains, language, q, searchIndex, showBrush],
+  );
+  // …and the Lanes grid drops the template facet too, so drilling into one lane
+  // doesn't shrink the grid to that single lane.
+  const laneChart = useMemo(
+    () =>
+      viewMode === "timeline" && !cejilLoading
+        ? entities.filter((e) => matchesAll(e, { ...filterState, typeIds: [] }, "date"))
+        : [],
+    [entities, dataSource, hasDocOnly, wantPublished, wantRestricted, statusActive, activeCountries.join(","), countryMode, activeDescriptors.join(","), descriptorMode, inheritedKey, chainKey, activeChains, language, q, searchIndex, viewMode, cejilLoading],
+  );
+
   // The full CEJIL corpus is thousands of entities — cap the rendered cards and
   // let the user reveal more, so the card/list grid never paints them all at once.
   const [visibleCount, setVisibleCount] = useState(DISPLAY_STEP);
@@ -356,26 +389,6 @@ export function LibraryView() {
             </button>
           )}
         </div>
-        <SegmentedControl
-          ariaLabel="Data source"
-          value={dataSource}
-          onChange={(v) => {
-            setDataSource(v as typeof dataSource);
-            // type/country ids differ per source — clear stale facets + preview.
-            setTypeFilters({});
-            setCountryFilters({});
-            setStatusFilters({});
-            setDescriptorFilters({});
-            setDateFrom("");
-            setDateTo("");
-            setInheritedFilters({});
-            setSelectedId(null);
-          }}
-          options={[
-            { id: "mock", label: "Sample" },
-            { id: "cejil", label: "CEJIL" },
-          ]}
-        />
         <Select
           value={sort}
           onChange={(v) => {
@@ -401,26 +414,27 @@ export function LibraryView() {
               { id: "cards", label: "Cards", icon: LayoutGrid },
               { id: "list", label: "List", icon: List },
               { id: "map", label: "Map", icon: MapIcon },
+              { id: "timeline", label: "Timeline", icon: CalendarRange },
             ]}
           />
         </div>
-        {viewMode !== "map" && (
-          <div className="hidden sm:block">
-            <DisplayMenu />
-          </div>
-        )}
-        <div className="hidden md:flex items-center gap-1">
-          {LANGUAGES.map((l) => (
-            <button
-              key={l}
-              onClick={() => setLanguage(l)}
-              className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors cursor-pointer ${
-                language === l ? "bg-vellum text-ink" : "bg-warm text-ink-tertiary hover:text-ink-secondary"
-              }`}
-            >
-              {l}
-            </button>
-          ))}
+        {/* Display is icon-only and ALWAYS mounted; the view-specific modifiers
+            (timeline layout) live inside its popover. Anything that appears and
+            disappears from this row shoves every other control sideways when you
+            change view — which is exactly what it used to do. */}
+        <div className="hidden sm:block">
+          <DisplayMenu />
+        </div>
+        {/* Languages: one dropdown of fixed width (codes, not names — a "Français"
+            label would resize the trigger and shift the row again). */}
+        <div className="hidden md:block">
+          <Select
+            value={language}
+            onChange={(v) => setLanguage(v as Language)}
+            ariaLabel="Language"
+            align="end"
+            options={LANGUAGES.map((l) => ({ value: l, label: l }))}
+          />
         </div>
         {menuTrigger}
       </div>
@@ -428,7 +442,9 @@ export function LibraryView() {
       {/* Results */}
       <div
         className={`flex-1 min-h-0 px-3 py-3 bg-warm ${
-          viewMode === "map" ? "flex flex-col overflow-hidden" : "overflow-auto"
+          viewMode === "map" || viewMode === "timeline"
+            ? "flex flex-col overflow-hidden"
+            : "overflow-auto"
         }`}
       >
         {activeFilterCount > 0 && (
@@ -515,6 +531,18 @@ export function LibraryView() {
               <LibraryMapView entities={filtered} />
             </Suspense>
           </div>
+        ) : viewMode === "timeline" ? (
+          <div className="flex-1 min-h-0">
+            <LibraryTimelineView
+              entities={filtered}
+              chart={timeChart}
+              laneChart={laneChart}
+              selectedId={selectedId}
+              onSelect={handleSelect}
+              onView={openEntity}
+              countByEntity={countByEntity}
+            />
+          </div>
         ) : filtered.length === 0 ? (
           <div className="flex items-center justify-center h-40 text-sm text-ink-muted">
             No entities match your filters.
@@ -547,7 +575,7 @@ export function LibraryView() {
           />
         )}
 
-        {!cejilLoading && viewMode !== "map" && shown.length < filtered.length && (
+        {!cejilLoading && viewMode !== "map" && viewMode !== "timeline" && shown.length < filtered.length && (
           <div className="flex justify-center pt-4">
             <button
               onClick={() => setVisibleCount((n) => n + DISPLAY_STEP)}
@@ -558,6 +586,9 @@ export function LibraryView() {
           </div>
         )}
       </div>
+
+      {/* Time brush — map + timeline */}
+      {showBrush && <TimeBrush entities={timeChart} />}
 
       {/* Footer action bar */}
       <div


### PR DESCRIPTION
Adds a time-based way into the Library, modelled on [ukraine.bellingcat.com](https://ukraine.bellingcat.com) — a canvas above, the range you're looking at below. Along the way it fixes a map that was fabricating its own data, and a Settings section whose three groups all lived behind one door.

20 commits. `tsc --noEmit` and `vite build` green.

## The timeline

**A time strip** under the results: a volume silhouette with a draggable window over it. It writes the *existing* `libraryDateFrom/To` atoms, so brushing narrows cards / list / map / timeline alike — no second filter path. Its chart is the results with every facet applied **except** the date one, so out-of-range volume stays visible (dimmed) rather than collapsing to the selection. Tap a period to select it; drag to brush. It's a display option (Display ▸ Chart ▸ Time strip), on by default, under **every** layout — there was never anything spatial about it that made it belong only to the map.

**Four layouts** (`utils/timeline.ts` holds the one shared scale, and all three tracks land their axis on the same pixel — measured, not eyeballed):

| | |
|---|---|
| **Rail** | The document's reference minimap, on time: periods as dots and counted rings. Clicking one *filters* the Library to that period. |
| **Density** | The same periods as bars, stacked by template — one global segment order down the track, or the stacks wouldn't be comparable. |
| **Spine** | A proportional chronology, one line per entity at its exact instant. Long silences elide with a labelled break ("14 months later") rather than 700px of dead air. |
| **Lanes** | A template × period grid; a cell drills into that slice. |

The tracks carry the minimap's whole-document / this-page toggle, as **whole-timeline / this-year**. Undated entities are counted, never silently dropped.

## The map was lying

`adapt.ts` set `geo: country ? CEJIL_COORDS[country] : undefined`. **Any entity that merely *named* a country got pinned to a hardcoded centroid** — so every judgment, resolution and separate vote became a "location", stacked onto a dozen country blobs. That's a country facet drawn on a map.

CEJIL ships real coordinates the adapter never read (`ubicaci_n_geogr_fica_geolocation` — the 343 *"Geolocalización de los hechos del caso"* entities — plus 30 país centroids). Those are now the only source of `geo`; the invented-centroid table is gone. **373 located entities across 352 places, instead of 4,398 across ~17.**

Three consequences had to be fixed for that to be usable:

- **Pins cluster by screen proximity**, not identical coordinates, and split as you zoom (38 pins → 117 at 4×). Identical-coordinate keying was fine for centroids and useless for real ones. Getting the zoom to reach the clustering needed two non-obvious fixes in `react-simple-maps`' `useZoomPan` — see `f37308b`.
- **Selection identifies the cluster**, not its shape. It matched on `(label, count)` while every multi-country cluster was labelled `"N locations"` — so clicking a pin over Venezuela also lit up pins over the Dominican Republic and Bolivia.
- **A geolocation inherits its Causa's date.** All 373 geolocated entities are undated, so *any* date filter emptied the map — the only entities that can be pinned were exactly the ones a date filter throws away. Narrow by design: geolocated entities only, from a Causa only; letting any undated entity borrow a date from any connected one would invent dates for ~1,100 others.

## Settings: three doors, three sections

The three groups all lived behind one door. *"User settings"* and *"System settings"* in the Settings dropdown navigated to the **same page with the same twenty-item rail** — the distinction was a label, not a place. Meanwhile the Tools dropdown was a hardcoded list of five mostly-**disabled** placeholders, sitting next to a settings rail whose Tools pages were real and worked.

Each surface now owns its own section list, and the rail scopes itself to whichever door you came in through:

- **Settings ▸ User settings** → the User group
- **Settings ▸ System settings** → the System group
- **Tools ▸ …** → the Tools group, which *is* the dropdown now, so those pages are finally reachable

Metadata/Paragraph Extraction move System → Tools (they're things you *run*, not things you configure) under an **ML tools** subsection. **Documentation** belongs to no group — it's the way *out* of all of them — so it's pinned under every rail and appended to both menus.

## Chrome

- **The toolbar stops moving.** Controls that appeared in one view and vanished in another shoved everything sideways on every switch. The collection picker moves to the navbar (it belongs to the destination), languages collapse to one dropdown, Display is icon-only and always mounted, and the timeline layouts live inside its popover.
- **Active filters live in the Filters panel** — the surface where they're *set*. The chip row above the results was a block that appeared and vanished (shoving the result set) and wrapped (re-flowing under the cursor mid-click, removing the wrong filter). The footer's `● N filters` opens a popover to see and remove them **without closing the entity you're reading**. Also collapses two `clearAll` implementations that had already drifted — one forgot the search box, the other the AND/OR facet modes.
- **Empty states** for the strip and the map. The strip used to *unmount*, dropping the results pane at the exact moment you're working out why you got nothing. The map drew an empty world, indistinguishable from one that failed to load — a card now sits over the geography and explains that only entities with coordinates of their own are plotted, because after the geolocation fix an empty map is usually **correct**.
- **Entity panel headers**: the type was a filled pill and the title was `text-xs` — the same size as the metadata labels below it. Type is now an eyebrow, the title is a heading. Shared by the drawer and `EntityOverlay` so they can't drift.

## Verification

Behaviour was driven in the browser rather than assumed. Pin counts, cluster selection, filter counts, axis positions across layouts, rail contents behind each door, and the results pane's top edge (unchanged at the same `y` with a filter applied and cleared) were all **measured**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)